### PR TITLE
Costmap2D Inflation optimizations

### DIFF
--- a/costmap_2d/include/costmap_2d/costmap_2d.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d.h
@@ -42,11 +42,20 @@
 #include <queue>
 #include <geometry_msgs/Point.h>
 #include <boost/thread.hpp>
+#include <map>
+
+#include <string>  // for string
+#include <algorithm>  // for min
 
 namespace costmap_2d
 {
+class Layer;
+class Costmap2D;
 
-//convenient for storing x/y point pairs
+typedef boost::shared_ptr<Costmap2D> sp_Costmap2D;
+
+
+// convenient for storing x/y point pairs
 struct MapLocation
 {
   unsigned int x;
@@ -59,7 +68,7 @@ struct MapLocation
  */
 class Costmap2D
 {
-  friend class CostmapTester; //Need this for gtest to work correctly
+  friend class CostmapTester;  // Need this for gtest to work correctly
 public:
   /**
    * @brief  Constructor for a costmap
@@ -98,6 +107,13 @@ public:
                          double win_size_y);
 
   /**
+   * @brief Create a new Cost Map at an equal or lower resolution
+   * @param factor  Resolution reduction factor.
+   * @return  New shared pointer of a Costmap2D object at an equal or lower resolution. The contents of the map are undefined.
+   */
+  sp_Costmap2D reducedResolutionCopy(int factor);
+
+  /**
    * @brief  Default constructor
    */
   Costmap2D();
@@ -116,12 +132,39 @@ public:
   unsigned char getCost(unsigned int mx, unsigned int my) const;
 
   /**
+   * @brief  Get the cost of a cell in the costmap
+   * @param index The offset from the start of the memory buffer holding the costmap
+   * @return The cost of the cell at the index
+   */
+  unsigned char getCost(unsigned int index) const;
+
+  /**
    * @brief  Set the cost of a cell in the costmap
    * @param mx The x coordinate of the cell
    * @param my The y coordinate of the cell
    * @param cost The cost to set the cell to
    */
   void setCost(unsigned int mx, unsigned int my, unsigned char cost);
+
+  /**
+   * @brief  Set the cost of a cell in the costmap
+   * @param index The index of the cell
+   * @param cost The cost to set the cell to
+   */
+  void setCost(unsigned int index, unsigned char cost);
+
+
+  /**
+   * @brief Get the flag determining if data propagation to sub-maps is enabled
+   * @return True if data propagation is enabled, False otherwise.
+   */
+  bool getPropagationEnabled() const;
+
+  /**
+   * @brief Set the flag to enable or disable data propagation to sub-maps
+   * @param New value (default true)
+   */
+  void setPropagationEnabled(bool b = true);
 
   /**
    * @brief  Convert from map coordinates to world coordinates
@@ -190,6 +233,7 @@ public:
    * @return A pointer to the underlying unsigned char array storing cost values
    */
   unsigned char* getCharMap() const;
+
 
   /**
    * @brief  Accessor for the x size of the costmap in cells
@@ -281,7 +325,61 @@ public:
   void resizeMap(unsigned int size_x, unsigned int size_y, double resolution, double origin_x,
                  double origin_y);
 
+  /**
+    * @brief Copy a window of cells from the calling Costmap2D to a destination Costmap2D
+    * @param src_x0 base x value of the calling window
+    * @param src_y0 base y value of the calling window
+    * @param dst_x0 base x value of the destination window
+    * @param dst_y0 base y value of the destination window
+    * @param xn Number of cells in the x direction to reset (point x0 + xn not changed)
+    * @param yn Number of cells in the y direction to reset (point y0 + yn not changed)
+    */
+  void copyCellsTo(Costmap2D &map, unsigned int src_x0, unsigned int src_y0,
+                                   unsigned int dst_x0, unsigned int dst_y0,
+                                   unsigned int xn, unsigned int yn) const;
+
+  void copyCellsTo(sp_Costmap2D map, unsigned int src_x0, unsigned int src_y0,
+                                     unsigned int dst_x0, unsigned int dst_y0,
+                                     unsigned int xn, unsigned int yn) const;
+
+  void copyCellsTo(Costmap2D& map, unsigned int x0, unsigned int y0,
+                                   unsigned int xn, unsigned int yn)  const;
+
+  void copyCellsTo(sp_Costmap2D map, unsigned int x0, unsigned int y0,
+                                     unsigned int xn, unsigned int yn)  const;
+
+  void copyCellsTo(Costmap2D& map) const;
+  void copyCellsTo(sp_Costmap2D map) const;
+
+  /**
+    * @brief Reset a window of the map to the default value
+    * @param x0 base x value of the window
+    * @param y0 base y value of the window
+    * @param xn Number of cells in the x direction to reset (point x0 + xn not changed)
+    * @param yn Number of cells in the y direction to reset (point y0 + yn not changed)
+    */
   void resetMap(unsigned int x0, unsigned int y0, unsigned int xn, unsigned int yn);
+
+  /**
+    * @brief Reset the entire map. Set all values to the default value
+    */
+  void resetMap();
+
+  /**
+    * @brief Reset a window of the map to a custom value
+    * @param x0 base x value of the window
+    * @param y0 base y value of the window
+    * @param xn Number of cells in the x direction to reset (point x0 + xn not changed)
+    * @param yn Number of cells in the y direction to reset (point y0 + yn not changed)
+    * @param value custom value to assign to the reset window
+    */
+  void resetMap(unsigned int x0, unsigned int y0, unsigned int xn, unsigned int yn, const unsigned char value);
+
+  /**
+    * @brief Reset the entire map to a custom value
+    * @param value custom value to assign to the entire map
+    */
+  void resetMap(const unsigned char value);
 
   /**
    * @brief  Given distance in the world... convert it to cells
@@ -289,6 +387,24 @@ public:
    * @return The equivalent cell distance
    */
   unsigned int cellDistance(double world_dist);
+
+  /**
+    * @brief Add a named child Costmap2D
+    * @param map The Costmap that will be attached to the parent Costmap
+    * @param map_name The name of the map
+    * @return The given Costmap2D
+    */
+  sp_Costmap2D addNamedCostmap2D(const std::string& map_name, sp_Costmap2D map);
+
+  // convenience version of above
+  sp_Costmap2D addNamedCostmap2D(sp_Costmap2D map, const std::string& map_name);
+
+  /**
+    * @brief Get a sub-map with a given name
+    * @param map_name The name of the map
+    * @return The named Costmap2D or a null shared pointer if not found
+    */
+  sp_Costmap2D getNamedCostmap2D(const std::string& map_name);
 
   boost::shared_mutex* getLock()
   {
@@ -315,11 +431,11 @@ protected:
                        unsigned int dm_lower_left_y, unsigned int dm_size_x, unsigned int region_size_x,
                        unsigned int region_size_y)
     {
-      //we'll first need to compute the starting points for each map
+      // we'll first need to compute the starting points for each map
       data_type* sm_index = source_map + (sm_lower_left_y * sm_size_x + sm_lower_left_x);
       data_type* dm_index = dest_map + (dm_lower_left_y * dm_size_x + dm_lower_left_x);
 
-      //now, we'll copy the source map into the destination map
+      // now, we'll copy the source map into the destination map
       for (unsigned int i = 0; i < region_size_y; ++i)
       {
         memcpy(dm_index, sm_index, region_size_x * sizeof(data_type));
@@ -338,12 +454,15 @@ protected:
    */
   virtual void resetMaps();
 
+
   /**
    * @brief  Initializes the costmap, static_map, and markers data structures
    * @param size_x The x size to use for map initialization
    * @param size_y The y size to use for map initialization
    */
   virtual void initMaps(unsigned int size_x, unsigned int size_y);
+
+
 
   /**
    * @brief  Raytrace a line and apply some action at each step
@@ -369,11 +488,11 @@ protected:
 
       unsigned int offset = y0 * size_x_ + x0;
 
-      //we need to chose how much to scale our dominant dimension, based on the maximum length of the line
+      // we need to chose how much to scale our dominant dimension, based on the maximum length of the line
       double dist = hypot(dx, dy);
-      double scale = std::min(1.0, max_length / dist);
+      double scale = (dist == 0.0) ? 1.0 : std::min(1.0, max_length / dist);
 
-      //if x is dominant
+      // if x is dominant
       if (abs_dx >= abs_dy)
       {
         int error_y = abs_dx / 2;
@@ -381,10 +500,9 @@ protected:
         return;
       }
 
-      //otherwise y is dominant
+      // otherwise y is dominant
       int error_x = abs_dy / 2;
       bresenham2D(at, abs_dy, abs_dx, error_x, offset_dy, offset_dx, offset, (unsigned int)(scale * abs_dy));
-
     }
 
 private:
@@ -425,6 +543,8 @@ protected:
   unsigned char* costmap_;
   unsigned char default_value_;
 
+  std::map<std::string, sp_Costmap2D> child_maps_;
+
   class MarkCell
   {
   public:
@@ -441,6 +561,8 @@ protected:
     unsigned char value_;
   };
 
+
+
   class PolygonOutlineCells
   {
   public:
@@ -449,7 +571,7 @@ protected:
     {
     }
 
-    //just push the relevant cells back onto the list
+    // just push the relevant cells back onto the list
     inline void operator()(unsigned int offset)
     {
       MapLocation loc;
@@ -463,6 +585,6 @@ protected:
     std::vector<MapLocation>& cells_;
   };
 };
-}
+}  // namespace costmap_2d
 
-#endif
+#endif  // COSTMAP_COSTMAP_2D_H_

--- a/costmap_2d/include/costmap_2d/costmap_2d.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d.h
@@ -153,19 +153,6 @@ public:
    */
   void setCost(unsigned int index, unsigned char cost);
 
-
-  /**
-   * @brief Get the flag determining if data propagation to sub-maps is enabled
-   * @return True if data propagation is enabled, False otherwise.
-   */
-  bool getPropagationEnabled() const;
-
-  /**
-   * @brief Set the flag to enable or disable data propagation to sub-maps
-   * @param New value (default true)
-   */
-  void setPropagationEnabled(bool b = true);
-
   /**
    * @brief  Convert from map coordinates to world coordinates
    * @param  mx The x map coordinate

--- a/costmap_2d/include/costmap_2d/costmap_layer.h
+++ b/costmap_2d/include/costmap_2d/costmap_layer.h
@@ -35,20 +35,21 @@
  * Author: Eitan Marder-Eppstein
  *         David V. Lu!!
  *********************************************************************/
-#ifndef COSTMAP_LAYER_H_
-#define COSTMAP_LAYER_H_
+#ifndef COSTMAP_2D_COSTMAP_LAYER_H_
+#define COSTMAP_2D_COSTMAP_LAYER_H_
 #include <ros/ros.h>
 #include <costmap_2d/layer.h>
 #include <costmap_2d/layered_costmap.h>
 
 namespace costmap_2d
 {
+
 class CostmapLayer : public Layer, public Costmap2D
 {
 public:
   CostmapLayer() : has_extra_bounds_(false), 
-    extra_min_x_( 1e6), extra_min_y_( 1e6),
-    extra_max_x_(-1e6), extra_max_y_(-1e6) {}
+    extra_min_x_( 1e6), extra_max_x_(-1e6),
+    extra_min_y_( 1e6), extra_max_y_(-1e6) {}
 
   bool isDiscretized()
   {
@@ -143,8 +144,8 @@ protected:
   
 private:
   double extra_min_x_, extra_max_x_, extra_min_y_, extra_max_y_;
-  
 };
-}
-#endif
 
+}  // namespace costmap_2d
+
+#endif  // COSTMAP_2D_COSTMAP_LAYER_H_

--- a/costmap_2d/include/costmap_2d/footprint_layer.h
+++ b/costmap_2d/include/costmap_2d/footprint_layer.h
@@ -35,8 +35,9 @@
  * Author: Eitan Marder-Eppstein
  *         David V. Lu!!
  *********************************************************************/
-#ifndef FOOTPRINT_COSTMAP_PLUGIN_H_
-#define FOOTPRINT_COSTMAP_PLUGIN_H_
+#ifndef COSTMAP_2D_FOOTPRINT_LAYER_H_
+#define COSTMAP_2D_FOOTPRINT_LAYER_H_
+
 #include <ros/ros.h>
 #include <costmap_2d/layer.h>
 #include <costmap_2d/layered_costmap.h>
@@ -49,6 +50,7 @@
 
 namespace costmap_2d
 {
+
 class FootprintLayer : public Layer
 {
 public:
@@ -57,7 +59,8 @@ public:
 
   virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y, double* max_x,
                              double* max_y);
-  virtual void updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
+  virtual void updateCosts(LayerActions* layer_actions, costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
+
 
 private:
   geometry_msgs::PolygonStamped footprint_; ///< Storage for polygon being published.
@@ -65,7 +68,15 @@ private:
   void reconfigureCB(costmap_2d::GenericPluginConfig &config, uint32_t level);
   ros::Publisher footprint_pub_;
   dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig> *dsrv_;
+
+
+  double fl_min_x_; ///< @brief FootprintLayer bounding box in world coordinates
+  double fl_min_y_; ///< @brief FootprintLayer bounding box in world coordinates
+  double fl_max_x_; ///< @brief FootprintLayer bounding box in world coordinates
+  double fl_max_y_; ///< @brief FootprintLayer bounding box in world coordinates
 };
-}
-#endif
+
+}  // namespace costmap_2d
+
+#endif  // COSTMAP_2D_FOOTPRINT_LAYER_H_
 

--- a/costmap_2d/include/costmap_2d/layer.h
+++ b/costmap_2d/include/costmap_2d/layer.h
@@ -34,17 +34,188 @@
  *
  * Author: David V. Lu!!
  *********************************************************************/
-#ifndef COSTMAP_PLUGIN_BASE_H_
-#define COSTMAP_PLUGIN_BASE_H_
+#ifndef COSTMAP_2D_COSTMAP_2D_LAYER_H_
+#define COSTMAP_2D_COSTMAP_2D_LAYER_H_
+
 #include <costmap_2d/costmap_2d.h>
 #include <costmap_2d/layered_costmap.h>
 #include <string>
 #include <tf/tf.h>
 #include <tf/transform_listener.h>
+#include <vector>
+#include <string>
+#include <geometry_msgs/Point32.h>
 
 namespace costmap_2d
 {
 class LayeredCostmap;
+class Layer;
+
+/**
+ * @class AABB
+ * @brief Axis aligned bounding box
+ */
+class AABB
+{
+public:
+  /**
+   * @brief Create an empty Axis Aligned Bounding Box with both points at the origin
+   */
+  AABB();
+
+  /**
+   * @brief Copy constructor
+   */
+  AABB(const AABB& r);
+
+  /**
+   * @brief Create an empty Axis Aligned Bounding Box with both points at the given location
+   */
+  AABB(int px, int py);
+
+  /**
+   * @brief Create an Axis Aligned Bounding Box that bounds the given points
+   */
+  AABB(int px1, int py1, int px2, int py2);
+
+  /**
+   * @brief Create an Axis Aligned Bounding Box about given points
+   */
+  AABB(const std::vector<geometry_msgs::Point>& pts);
+
+  /**
+   * @brief Determine if this AABB is the same as another with possible tolerance
+   * @param r AABB to compare against
+   * @param tol Tolerance of compairson (default 0)
+   */
+  bool same(const AABB& r, int tol=0);
+
+  void copyTo(AABB& dst) const;
+
+  void expandBoundingBox(const AABB& bb);
+
+  /**
+   * @brief Expand the bounding box by a constant value
+   * @param r expansion margin
+   */
+  void expandBoundingBox(int r);
+
+  bool inside(int px, int py, int margin = 0) const;
+  bool inside(const AABB& bb, int margin = 0) const;
+
+  /**
+   * @brief Clip the passed AABB against the calling AABB
+   * @param bb AABB to be clipped
+   * @param clipped destination AABB representing the clipped bounding box
+   */
+  void clip(const AABB& bb, AABB& clipped) const;
+
+  /**
+   * @brief Make sure max coordinates are not smaller than min coordinates.
+   */
+  void clampBounds();
+
+  /**
+   * @brief Compute how much of the given AABB is inside the calling AABB as a ratio of areas
+   * @param bb The AABB to use as a test
+   */
+  double ratioInside(const AABB& bb) const;
+
+  int area() const;
+
+  int xn() const;
+  int yn() const;
+
+  int x0() const;
+  int y0() const;
+
+  /**
+   * @brief Determine if this AABB intersects another AABB
+   * @param bb AABB to compare against
+   * @param margin extra margin applied to the AABBs. A positive margin will make side by side AABBs appear to intersect. Default 0.
+   */
+  bool intersect(const AABB& bb, int margin = 0) const;
+
+  bool initialized() const {return initialized_;}
+  void setInitialized(bool b) {initialized_ = b;}
+
+
+  /**
+   * @brief Static method that will take a vector of bounding boxes and modify it so that overlapping boxes are merged
+   * @param vec_aabb the vector of boxes that will be merged. This vector is modified to contain the solution
+   * @param margin extra margin applied to the AABBs. A positive margin will make side by side AABBs appear to intersect. Default 0.
+   */
+  static void mergeIntersecting(std::vector<AABB>& vec_aabb, int margin=0);
+
+  int min_x, min_y;
+  int max_x, max_y;
+  bool initialized_;
+};
+
+/**
+ * @class LayerActions
+ * @brief Auxiliary storage object to track actions taken by the layer plugins to help with optimization.
+ */
+class LayerActions
+{
+public:
+  LayerActions() {}
+
+  enum Action{
+    NONE,
+    OVERWRITE,
+    TRUEOVERWRITE,
+    MODIFY,
+    MAX
+  };
+
+  // define an action in terms of the destination map
+  void addAction(const AABB& r, Costmap2D *map, LayerActions::Action a, const char* file, unsigned int line);
+
+  // define an action from one map to another
+  void addAction(const AABB& src_rect, Costmap2D *src_map, const AABB& dst_rect, Costmap2D *dst_map, LayerActions::Action a, const char* file, unsigned int line);
+  void clear();
+
+  void copyTo(LayerActions& la_dest);
+  void appendActionTo(LayerActions& la_dest, int action_index);
+
+  void copyToWithMatchingDest(LayerActions& la_dest, Costmap2D* match_pattern);
+
+  int size() {return (int)v_actions.size();}
+
+  LayerActions::Action actionAt(int idx);
+  bool actionIs(int idx, Action a);
+  bool validIndex(int idx);
+
+  Costmap2D* destinationCostmapAt(int idx);
+  Costmap2D* sourceCostmapAt(int idx);
+
+  const AABB& sourceAABBAt(int idx);
+  const AABB& destinationAABBAt(int idx);
+
+
+  /**
+   * @brief Look at the sequence of actions and determine if some can be merged
+   * @param tolerance Some rectanges may not quite overlap but if they are within the given tolerance then we will merge them
+   */
+  void optimize(int tolerance=0);
+
+  void writeToFile(const char* filename);
+
+  // These define the actions that we have collected
+  // we have the source and destination rectangle with the corresponding maps
+  // and the action type
+  std::vector<AABB>                 v_source_rect;
+  std::vector<AABB>                 v_destination_rect;
+  std::vector<Costmap2D*>           v_source_maps;
+  std::vector<Costmap2D*>           v_destination_maps;
+  std::vector<LayerActions::Action> v_actions;
+
+  std::vector<std::string> v_action_file;
+  std::vector<int>         v_action_line;
+private:
+  AABB nullAABB;
+};
 
 class Layer
 {
@@ -53,17 +224,43 @@ public:
 
   void initialize( LayeredCostmap* parent, std::string name, tf::TransformListener *tf );
 
+  /**
+   * @brief This is called by the LayeredCostmap to poll this plugin as to how
+   *        much of the costmap it needs to update. Each layer can increase
+   *        the size of this bounds.
+   *
+   * For more details, see "Layered Costmaps for Context-Sensitive Navigation",
+   * by Lu et. Al, IROS 2014.
+   */
   virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
-                             double* max_x, double* max_y) {}
-  virtual void updateCosts(Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j) {}
+                            double* max_x, double* max_y) {}
 
-  virtual void deactivate() {}   // stop publishers
-  virtual void activate() {}     // restart publishers if they've been stopped
+  /**
+   * @brief Actually update the underlying costmap, only within the bounds
+   *        calculated during UpdateBounds().
+   */
+  virtual void updateCosts(LayerActions* layer_actions, Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j) {}
+
+  /** @brief Stop publishers. */
+  virtual void deactivate() {}
+
+  /** @brief Restart publishers if they've been stopped. */
+  virtual void activate() {}
 
   virtual void reset() {}
 
   virtual ~Layer() {}
 
+  /**
+   * @brief Check to make sure all the data in the layer is up to date.
+   *        If the layer is not up to date, then it may be unsafe to
+   *        plan using the data from this layer, and the planner may
+   *        need to know.
+   *
+   *        A layer's current state should be managed by the protected
+   *        variable current_.
+   * @return Whether the data in the layer is up to date.
+   */
   bool isCurrent() const
   {
     return current_;
@@ -102,5 +299,6 @@ private:
   std::vector<geometry_msgs::Point> footprint_spec_;
 };
 
-} // namespace costmap_2d
-#endif
+}  // namespace costmap_2d
+
+#endif  // COSTMAP_2D_COSTMAP_2D_LAYER_H_

--- a/costmap_2d/include/costmap_2d/layered_costmap.h
+++ b/costmap_2d/include/costmap_2d/layered_costmap.h
@@ -35,8 +35,8 @@
  * Author: Eitan Marder-Eppstein
  *         David V. Lu!!
  *********************************************************************/
-#ifndef LAYERED_COSTMAP_H_
-#define LAYERED_COSTMAP_H_
+#ifndef COSTMAP_2D_LAYERED_COSTMAP_H_
+#define COSTMAP_2D_LAYERED_COSTMAP_H_
 
 #include <costmap_2d/cost_values.h>
 #include <costmap_2d/layer.h>
@@ -155,8 +155,6 @@ public:
   double getInscribedRadius() { return inscribed_radius_; }
 
 private:
-  void updateUsingPlugins(std::vector<boost::shared_ptr<Layer> > &plugins);
-
   Costmap2D costmap_;
   std::string global_frame_;
 
@@ -173,8 +171,7 @@ private:
   double circumscribed_radius_, inscribed_radius_;
   std::vector<geometry_msgs::Point> footprint_;
 };
-}
-;
-// namespace layered_costmap
 
-#endif
+}  // namespace costmap_2d
+
+#endif  // COSTMAP_2D_LAYERED_COSTMAP_H_

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -35,8 +35,9 @@
  * Author: Eitan Marder-Eppstein
  *         David V. Lu!!
  *********************************************************************/
-#ifndef OBSTACLE_COSTMAP_PLUGIN_H_
-#define OBSTACLE_COSTMAP_PLUGIN_H_
+#ifndef COSTMAP_2D_OBSTACLE_LAYER_H_
+#define COSTMAP_2D_OBSTACLE_LAYER_H_
+
 #include <ros/ros.h>
 #include <costmap_2d/costmap_layer.h>
 #include <costmap_2d/layered_costmap.h>
@@ -55,21 +56,26 @@
 #include <costmap_2d/ObstaclePluginConfig.h>
 #include <costmap_2d/footprint_layer.h>
 
+#include <string>  // for string
+#include <vector>  // for vector<>
+
 namespace costmap_2d
 {
+
 class ObstacleLayer : public CostmapLayer
 {
 public:
   ObstacleLayer()
   {
-    costmap_ = NULL; // this is the unsigned char* member of parent class Costmap2D.
+    costmap_ = NULL;  // this is the unsigned char* member of parent class Costmap2D.
   }
 
   virtual ~ObstacleLayer();
   virtual void onInitialize();
-  virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y, double* max_x,
-                             double* max_y);
-  virtual void updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
+  virtual void updateBounds(double robot_x, double robot_y, double robot_yaw,
+                            double* min_x, double* min_y, double* max_x, double* max_y);
+  virtual void updateCosts(LayerActions *layer_actions, Costmap2D &master_grid,
+                           int min_i, int min_j, int max_i, int max_j);
 
   virtual void activate();
   virtual void deactivate();
@@ -88,7 +94,7 @@ public:
     * @param message The message returned from a message notifier 
     * @param buffer A pointer to the observation buffer to update
     */
-   void laserScanValidInfCallback(const sensor_msgs::LaserScanConstPtr& message, 
+  void laserScanValidInfCallback(const sensor_msgs::LaserScanConstPtr& message,
                                   const boost::shared_ptr<ObservationBuffer>& buffer);
 
   /**
@@ -112,7 +118,6 @@ public:
   void clearStaticObservations(bool marking, bool clearing);
 
 protected:
-
   virtual void setupDynamicReconfigure(ros::NodeHandle& nh);
 
   /**
@@ -137,25 +142,34 @@ protected:
    * @param max_x
    * @param max_y
    */
-  virtual void raytraceFreespace(const costmap_2d::Observation& clearing_observation, double* min_x, double* min_y,
-                                 double* max_x, double* max_y);
+  virtual void raytraceFreespace(const costmap_2d::Observation& clearing_observation,
+                                 double* min_x, double* min_y, double* max_x, double* max_y);
 
-  void updateRaytraceBounds(double ox, double oy, double wx, double wy, double range, double* min_x, double* min_y,
-			    double* max_x, double* max_y);
+  void updateRaytraceBounds(double ox, double oy, double wx, double wy, double range,
+                            double* min_x, double* min_y, double* max_x, double* max_y);
 
   /** @brief Overridden from superclass Layer to pass new footprint into footprint_layer_. */
   virtual void onFootprintChanged();
 
-  std::string global_frame_; ///< @brief The global frame for the costmap
-  double max_obstacle_height_; ///< @brief Max Obstacle Height
+  std::string global_frame_;  ///< @brief The global frame for the costmap
+  double max_obstacle_height_;  ///< @brief Max Obstacle Height
 
-  laser_geometry::LaserProjection projector_; ///< @brief Used to project laser scans into point clouds
+  laser_geometry::LaserProjection projector_;  ///< @brief Used to project laser scans into point clouds
 
-  std::vector<boost::shared_ptr<message_filters::SubscriberBase> > observation_subscribers_; ///< @brief Used for the observation message filters
-  std::vector<boost::shared_ptr<tf::MessageFilterBase> > observation_notifiers_; ///< @brief Used to make sure that transforms are available for each sensor
-  std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > observation_buffers_; ///< @brief Used to store observations from various sensors
-  std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > marking_buffers_; ///< @brief Used to store observation buffers used for marking obstacles
-  std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > clearing_buffers_; ///< @brief Used to store observation buffers used for clearing obstacles
+  /// @brief Used for the observation message filters
+  std::vector<boost::shared_ptr<message_filters::SubscriberBase> > observation_subscribers_;
+
+  /// @brief Used to make sure that transforms are available for each sensor
+  std::vector<boost::shared_ptr<tf::MessageFilterBase> > observation_notifiers_;
+
+  /// @brief Used to store observations from various sensors
+  std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > observation_buffers_;
+
+  /// @brief Used to store observation buffers used for marking obstacles
+  std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > marking_buffers_;
+
+  /// @brief Used to store observation buffers used for clearing obstacles
+  std::vector<boost::shared_ptr<costmap_2d::ObservationBuffer> > clearing_buffers_;
 
   // Used only for testing purposes
   std::vector<costmap_2d::Observation> static_clearing_observations_, static_marking_observations_;
@@ -163,13 +177,19 @@ protected:
   bool rolling_window_;
   dynamic_reconfigure::Server<costmap_2d::ObstaclePluginConfig> *dsrv_;
 
-  FootprintLayer footprint_layer_; ///< @brief clears the footprint in this obstacle layer.
-  
+  FootprintLayer footprint_layer_;  ///< @brief clears the footprint in this obstacle layer.
+
   int combination_method_;
 
 private:
   void reconfigureCB(costmap_2d::ObstaclePluginConfig &config, uint32_t level);
-};
-}
-#endif
 
+  int rt_min_x_;  ///< @brief Ray trace bounding box in cell coordinates
+  int rt_min_y_;  ///< @brief Ray trace bounding box in cell coordinates
+  int rt_max_x_;  ///< @brief Ray trace bounding box in cell coordinates
+  int rt_max_y_;  ///< @brief Ray trace bounding box in cell coordinates
+};
+
+}  // namespace costmap_2d
+
+#endif  // COSTMAP_2D_OBSTACLE_LAYER_H_

--- a/costmap_2d/include/costmap_2d/static_layer.h
+++ b/costmap_2d/include/costmap_2d/static_layer.h
@@ -35,8 +35,9 @@
  * Author: Eitan Marder-Eppstein
  *         David V. Lu!!
  *********************************************************************/
-#ifndef STATIC_COSTMAP_PLUGIN_H_
-#define STATIC_COSTMAP_PLUGIN_H_
+#ifndef COSTMAP_2D_STATIC_LAYER_H_
+#define COSTMAP_2D_STATIC_LAYER_H_
+
 #include <ros/ros.h>
 #include <costmap_2d/costmap_layer.h>
 #include <costmap_2d/layered_costmap.h>
@@ -48,6 +49,7 @@
 
 namespace costmap_2d
 {
+
 class StaticLayer : public CostmapLayer
 {
 public:
@@ -60,7 +62,7 @@ public:
 
   virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y, double* max_x,
                              double* max_y);
-  virtual void updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
+  virtual void updateCosts(LayerActions *layer_actions, Costmap2D &master_grid, int min_i, int min_j, int max_i, int max_j);
 
   virtual void matchSize();
 
@@ -92,6 +94,7 @@ private:
   mutable boost::recursive_mutex lock_;
   dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig> *dsrv_;
 };
-}
-#endif
 
+}  // namespace costmap_2d
+
+#endif  // COSTMAP_2D_STATIC_LAYER_H_

--- a/costmap_2d/include/costmap_2d/voxel_layer.h
+++ b/costmap_2d/include/costmap_2d/voxel_layer.h
@@ -35,8 +35,9 @@
  * Author: Eitan Marder-Eppstein
  *         David V. Lu!!
  *********************************************************************/
-#ifndef VOXEL_COSTMAP_PLUGIN_H_
-#define VOXEL_COSTMAP_PLUGIN_H_
+#ifndef COSTMAP_2D_VOXEL_LAYER_H_
+#define COSTMAP_2D_VOXEL_LAYER_H_
+
 #include <ros/ros.h>
 #include <costmap_2d/layer.h>
 #include <costmap_2d/layered_costmap.h>
@@ -54,6 +55,7 @@
 #include <costmap_2d/VoxelPluginConfig.h>
 #include <costmap_2d/obstacle_layer.h>
 #include <voxel_grid/voxel_grid.h>
+
 namespace costmap_2d
 {
 
@@ -80,9 +82,10 @@ public:
   virtual void matchSize();
   virtual void reset();
 
-
 protected:
   virtual void setupDynamicReconfigure(ros::NodeHandle& nh);
+
+  virtual void resetMaps();
 
 private:
   void reconfigureCB(costmap_2d::VoxelPluginConfig &config, uint32_t level);
@@ -140,8 +143,8 @@ private:
   {
     return sqrt((x1 - x0) * (x1 - x0) + (y1 - y0) * (y1 - y0) + (z1 - z0) * (z1 - z0));
   }
-
 };
-}
-#endif
 
+}  // namespace costmap_2d
+
+#endif  // COSTMAP_2D_VOXEL_LAYER_H_

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -1,9 +1,50 @@
-#include<costmap_2d/inflation_layer.h>
-#include<costmap_2d/costmap_math.h>
-#include<costmap_2d/footprint.h>
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2008, 2013, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Eitan Marder-Eppstein
+ *         David V. Lu!!
+ *********************************************************************/
+#include <costmap_2d/inflation_layer.h>
+#include <costmap_2d/costmap_math.h>
+#include <costmap_2d/footprint.h>
 #include <pluginlib/class_list_macros.h>
+#include <limits>
+#include <algorithm>
+#include <vector>
 
 PLUGINLIB_EXPORT_CLASS(costmap_2d::InflationLayer, costmap_2d::Layer)
+
 using costmap_2d::LETHAL_OBSTACLE;
 using costmap_2d::INSCRIBED_INFLATED_OBSTACLE;
 using costmap_2d::NO_INFORMATION;
@@ -12,11 +53,15 @@ namespace costmap_2d
 {
 
 InflationLayer::InflationLayer()
-  : inflation_radius_( 0 )
-  , weight_( 0 )
+  : inflation_radius_(0)
+  , weight_(0)
   , cell_inflation_radius_(0)
   , cached_cell_inflation_radius_(0)
   , dsrv_(NULL)
+  , seen_(NULL)
+  , cached_costs_(NULL)
+  , cached_distances_(NULL)
+  , cached_kernel_inflated_(false)
 {
   access_ = new boost::shared_mutex();
 }
@@ -27,13 +72,16 @@ void InflationLayer::onInitialize()
     boost::unique_lock < boost::shared_mutex > lock(*access_);
     ros::NodeHandle nh("~/" + name_), g_nh;
     current_ = true;
+    if (seen_)
+      delete[] seen_;
     seen_ = NULL;
+    seen_size_ = 0;
     need_reinflation_ = false;
 
     dynamic_reconfigure::Server<costmap_2d::InflationPluginConfig>::CallbackType cb = boost::bind(
         &InflationLayer::reconfigureCB, this, _1, _2);
 
-    if(dsrv_ != NULL){
+    if (dsrv_ != NULL){
       dsrv_->clearCallback();
       dsrv_->setCallback(cb);
     }
@@ -42,7 +90,6 @@ void InflationLayer::onInitialize()
       dsrv_ = new dynamic_reconfigure::Server<costmap_2d::InflationPluginConfig>(ros::NodeHandle("~/" + name_));
       dsrv_->setCallback(cb);
     }
-
   }
 
   matchSize();
@@ -75,14 +122,15 @@ void InflationLayer::matchSize()
 
   unsigned int size_x = costmap->getSizeInCellsX(), size_y = costmap->getSizeInCellsY();
   if (seen_)
-    delete seen_;
+    delete[] seen_;
   seen_ = new bool[size_x * size_y];
+  seen_size_ = size_x * size_y;
 }
 
 void InflationLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x,
                                            double* min_y, double* max_x, double* max_y)
 {
-  if( need_reinflation_ )
+  if (need_reinflation_)
   {
     // For some reason when I make these -<double>::max() it does not
     // work with Costmap2D::worldToMapEnforceBounds(), so I'm using
@@ -98,27 +146,138 @@ void InflationLayer::updateBounds(double robot_x, double robot_y, double robot_y
 void InflationLayer::onFootprintChanged()
 {
   inscribed_radius_ = layered_costmap_->getInscribedRadius();
-  cell_inflation_radius_ = cellDistance( inflation_radius_ );
+  cell_inflation_radius_ = cellDistance(inflation_radius_);
   computeCaches();
   need_reinflation_ = true;
 
-  ROS_DEBUG( "InflationLayer::onFootprintChanged(): num footprint points: %lu, inscribed_radius_ = %.3f, inflation_radius_ = %.3f",
-             layered_costmap_->getFootprint().size(), inscribed_radius_, inflation_radius_ );
+  ROS_DEBUG("InflationLayer::onFootprintChanged(): num footprint points: %lu, "
+            "inscribed_radius_ = %.3f, inflation_radius_ = %.3f",
+            layered_costmap_->getFootprint().size(), inscribed_radius_, inflation_radius_);
 }
 
-void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i,
-                                          int max_j)
+void InflationLayer::updateCosts(Costmap2D &master_grid, int min_i, int min_j, int max_i, int max_j)
+{
+  return updateCostsPQ(master_grid, min_i, min_j, max_i, max_j);
+}
+
+// Apply inflation update rule on a contiguous row of memory
+static void updateCostsOverlay_row_helper(unsigned char* dest, const unsigned char* overlay, unsigned int n)
+{
+  for (int i = 0; i < n; i++)
+  {
+    unsigned char& old_cost = dest[i];
+    const unsigned char& cost = overlay[i];
+
+    if (old_cost == NO_INFORMATION && cost >= INSCRIBED_INFLATED_OBSTACLE)
+      old_cost = cost;
+    else
+      old_cost = std::max(old_cost, cost);
+  }
+}
+
+// This helper function will overlay a source costmap onto a destination costmap with
+// logic to keep thing in bounds. The overlay is governed by the inflation update rules
+static void updateCostsOverlay_block_helper(Costmap2D* dest, Costmap2D* src, int _start_dest_i, int _start_dest_j)
+{
+  const int nsi = src->getSizeInCellsX();
+  const int nsj = src->getSizeInCellsY();
+
+  const int ndi = dest->getSizeInCellsX();
+  const int ndj = dest->getSizeInCellsX();
+
+  int start_dest_i = std::max(0, _start_dest_i);
+  int start_dest_j = std::max(0, _start_dest_j);
+
+  int end_dest_i = std::min(ndi, _start_dest_i + nsi);
+  int end_dest_j = std::min(ndj, _start_dest_j + nsj);
+
+  int start_src_i = start_dest_i - _start_dest_i;
+  int start_src_j = start_dest_j - _start_dest_j;
+
+  int range_i = end_dest_i - start_dest_i;
+  int range_j = end_dest_j - start_dest_j;
+
+  unsigned char* dest_array = dest->getCharMap();
+  unsigned char*  src_array =  src->getCharMap();
+
+  for (int j = 0; j < range_j; j++)
+  {
+    int dest_index = dest->getIndex(start_dest_i, start_dest_j + j);
+    int  src_index =  src->getIndex(start_src_i,  start_src_j  + j);
+
+    updateCostsOverlay_row_helper(dest_array + dest_index, src_array + src_index, range_i);
+  }
+}
+
+
+void InflationLayer::updateCostsOverlay(Costmap2D &master_grid, int min_i, int min_j, int max_i, int max_j)
+{
+  if (!cached_kernel_inflated_)
+  {
+    updateCostsPQ(* cached_kernel_.get(), 0, 0, cached_kernel_->getSizeInCellsX(), cached_kernel_->getSizeInCellsX());
+    cached_kernel_inflated_ = true;
+  }
+
+  boost::unique_lock < boost::shared_mutex > lock(*access_);
+  if (!enabled_)
+    return;
+
+  unsigned char* master_array = master_grid.getCharMap();
+  unsigned int size_x = master_grid.getSizeInCellsX(), size_y = master_grid.getSizeInCellsY();
+
+  // We need to include in the inflation cells outside the bounding
+  // box min_i...max_j, by the amount cell_inflation_radius_.  Cells
+  // up to that distance outside the box can still influence the costs
+  // stored in cells inside the box.
+  min_i -= cell_inflation_radius_;
+  min_j -= cell_inflation_radius_;
+  max_i += cell_inflation_radius_;
+  max_j += cell_inflation_radius_;
+
+  min_i = std::max(0, min_i);
+  min_j = std::max(0, min_j);
+  max_i = std::min(static_cast<int>(size_x), max_i);
+  max_j = std::min(static_cast<int>(size_y), max_j);
+
+  for (int j = min_j; j < max_j; j++)
+  {
+    for (int i = min_i; i < max_i; i++)
+    {
+      if (master_grid.getCost(i, j) == LETHAL_OBSTACLE)
+      {
+        updateCostsOverlay_block_helper(&master_grid, cached_kernel_.get(),
+                                        i - cached_kernel_cnx_, j - cached_kernel_cny_);
+      }
+    }
+  }
+}
+
+
+
+void InflationLayer::updateCostsPQ(Costmap2D &master_grid, int min_i, int min_j, int max_i, int max_j)
 {
   boost::unique_lock < boost::shared_mutex > lock(*access_);
   if (!enabled_)
     return;
 
-  //make sure the inflation queue is empty at the beginning of the cycle (should always be true)
+  // make sure the inflation queue is empty at the beginning of the cycle (should always be true)
   ROS_ASSERT_MSG(inflation_queue_.empty(), "The inflation queue must be empty at the beginning of inflation");
 
   unsigned char* master_array = master_grid.getCharMap();
   unsigned int size_x = master_grid.getSizeInCellsX(), size_y = master_grid.getSizeInCellsY();
 
+  if (seen_ == NULL) {
+    ROS_ERROR("seen is NULL");
+    seen_ = new bool[size_x * size_y];
+    seen_size_ = size_x * size_y;
+  }
+  else if (seen_size_ != size_x * size_y)
+  {
+    ROS_ERROR("seen size is wrong");
+    delete[] seen_;
+    seen_ = new bool[size_x * size_y];
+    seen_size_ = size_x * size_y;
+  }
   memset(seen_, false, size_x * size_y * sizeof(bool));
 
   // We need to include in the inflation cells outside the bounding
@@ -130,10 +289,10 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
   max_i += cell_inflation_radius_;
   max_j += cell_inflation_radius_;
 
-  min_i = std::max( 0, min_i );
-  min_j = std::max( 0, min_j );
-  max_i = std::min( int( size_x  ), max_i );
-  max_j = std::min( int( size_y  ), max_j );
+  min_i = std::max(0, min_i);
+  min_j = std::max(0, min_j);
+  max_i = std::min(static_cast<int>(size_x), max_i);
+  max_j = std::min(static_cast<int>(size_y), max_j);
 
   for (int j = min_j; j < max_j; j++)
   {
@@ -148,9 +307,11 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
     }
   }
 
+
+
   while (!inflation_queue_.empty())
   {
-    //get the highest priority cell and pop it off the priority queue
+    // get the highest priority cell and pop it off the priority queue
     const CellData& current_cell = inflation_queue_.top();
 
     unsigned int index = current_cell.index_;
@@ -159,10 +320,10 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
     unsigned int sx = current_cell.src_x_;
     unsigned int sy = current_cell.src_y_;
 
-    //pop once we have our cell info
+    // pop once we have our cell info
     inflation_queue_.pop();
 
-    //attempt to put the neighbors of the current cell onto the queue
+    // attempt to put the neighbors of the current cell onto the queue
     if (mx > 0)
       enqueue(master_array, index - 1, mx - 1, my, sx, sy);
     if (my > 0)
@@ -172,6 +333,161 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
     if (my < size_y - 1)
       enqueue(master_array, index + size_x, mx, my + 1, sx, sy);
   }
+}
+
+
+// NOTE:
+// This method could be refactored a bit. There are 2 blocks of code that are repeated
+// Look for
+//    const AABB& dst = l_acts.destinationAABBAt(i);
+void InflationLayer::updateCosts(LayerActions* layer_actions, costmap_2d::Costmap2D& master_grid,
+                                 int min_i, int min_j, int max_i, int max_j)
+{
+  if (!enabled_)
+    return;
+
+  // The old, full method has been wrapped in a function so we can reuse it.
+  // Reproducing previous results, ignoring the layer actions, can be accomplished
+  // with:
+  // return updateCostsPQ(master_grid, min_i, min_j, max_i, max_j);
+  //
+  // Newer overlay style update can be applied globally with:
+  // return updateCostsOverlay(master_grid, min_i, min_j, max_i, max_j);
+
+  // We now have a list of all the actions that got us to this point.
+  // Hopefully some actions will have associated, pre-calculated inflations data
+  // and other layers will mark areas where we need to re-inflate.
+
+  // First we need to look at all the old actions that made modifications
+  // to the given master_grid and optimize them, essentially we don't want
+  // to inflate the same area twice
+
+  LayerActions l_acts;
+  layer_actions->copyToWithMatchingDest(l_acts, &master_grid);
+  l_acts.optimize();
+
+  sp_Costmap2D workspace = master_grid.getNamedCostmap2D("Workspace");
+  if (workspace.get() == 0)
+    workspace = master_grid.addNamedCostmap2D(master_grid.reducedResolutionCopy(1), "Workspace");
+
+  // build an AABB of the updateCostsBounds so we can clamp large ranges
+  // against it small windows
+  AABB updateCostsBounds(min_i, min_j, max_i, max_j);
+
+  // we want to track the area of the actions so we know how much
+  // of the master_grid we need to fall back on
+  AABB availableData;
+
+  // track how much data is pre-inflated
+  std::vector<AABB> inflatedData;
+
+  // track how much data has pending inflation required
+  std::vector<AABB> uninflatedData;
+
+  // now we can start marching up the actions
+  for (int i = 0; i < l_acts.size(); i++)
+  {
+    if (l_acts.actionAt(i) == LayerActions::TRUEOVERWRITE)
+    {
+      // if it's a true overwrite then we can lay down a copy of the cached inflated data
+      Costmap2D* src = l_acts.sourceCostmapAt(i);
+      if (src)
+      {
+        int src_nx = src->getSizeInCellsX();
+        int src_ny = src->getSizeInCellsY();
+        sp_Costmap2D inflated = src->getNamedCostmap2D("Inflated");
+
+        if (inflated.get() == 0)  // then we don't have a cache of the inflated data
+        {
+          inflated = src->reducedResolutionCopy(1);
+          src->copyCellsTo(inflated);
+
+          // inflate cached data
+          updateCosts(*inflated.get(), 0, 0, src_nx, src_ny);
+
+          // add inflated data to the source map so we have it next time
+          src->addNamedCostmap2D(inflated, "Inflated");
+        }
+
+        // only copying the region that we are interested in
+        inflated->copyCellsTo(workspace,
+                              updateCostsBounds.x0(), updateCostsBounds.y0(),
+                              updateCostsBounds.xn(), updateCostsBounds.yn());
+
+        // remembering that we have good data
+        inflatedData.push_back(AABB(updateCostsBounds));
+      }
+      else  // no defined source, need to work with master_grid
+      {
+        const AABB& dst = l_acts.destinationAABBAt(i);
+        if (dst.initialized())
+        {
+          master_grid.copyCellsTo(workspace,
+                                  dst.x0(), dst.y0(),
+                                  dst.xn(), dst.yn());
+
+          // mark that we need to inflate this data
+          uninflatedData.push_back(AABB(dst));
+        }
+        else
+        {
+          // This is a problem that shouldn't be encountered if everything has been done properly.
+          ROS_DEBUG("(inflation_layer.cpp:%d) Destination bounding box uninitialized, "
+                    "falling back to global inflation.", __LINE__);
+
+          // Falling back to old method: not fancy but it works
+          return updateCostsPQ(master_grid, min_i, min_j, max_i, max_j);
+        }
+      }
+    }
+    else  // l_acts.actionAt(i) != LayerActions::TRUEOVERWRITE
+    {
+      if (l_acts.actionAt(i) != LayerActions::NONE)
+      {
+        // copy from the master to the workspace and mark to inflate the window
+        const AABB& dst = l_acts.destinationAABBAt(i);
+        if (dst.initialized())
+        {
+          master_grid.copyCellsTo(workspace,
+                                  dst.x0(), dst.y0(),
+                                  dst.xn(), dst.yn());
+
+          // mark that we need to inflate this data
+          uninflatedData.push_back(AABB(dst));
+        }
+        else
+        {
+          // This is a problem that shouldn't be encountered if everything has been done properly.
+          ROS_DEBUG("(inflation_layer.cpp:%d) Destination bounding box uninitialized, "
+                    "falling back to global inflation.", __LINE__);
+
+          // Falling back to old method: not fancy but it works
+          return updateCostsPQ(master_grid, min_i, min_j, max_i, max_j);
+        }
+      }
+    }
+  }
+
+  // At this point we have data on the workspace and lists of
+  // inflated and uninflated regions.
+  // The uninflated trumps inflated so we need to merge the
+  // uninflated list and apply inflation piecemeal only where it is needed
+
+  int inflation_margin = cellDistance(inflation_radius_);
+  AABB::mergeIntersecting(uninflatedData, inflation_margin);
+
+  for (int i = 0; i < uninflatedData.size(); i++)
+  {
+    AABB& to_inflate = uninflatedData[i];
+
+    // and here it is: We are inflating only the required sections
+    updateCosts(*workspace.get(), to_inflate.min_x, to_inflate.min_y, to_inflate.max_x, to_inflate.max_y);
+  }
+
+  layer_actions->clear();
+
+  // Now we will copy from the workspace to the master_grid
+  workspace->copyCellsTo(master_grid, min_i, min_j, max_i, max_j);
 }
 
 /**
@@ -186,18 +502,21 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
 inline void InflationLayer::enqueue(unsigned char* grid, unsigned int index, unsigned int mx, unsigned int my,
                                             unsigned int src_x, unsigned int src_y)
 {
-
-  //set the cost of the cell being inserted
+  // set the cost of the cell being inserted
   if (!seen_[index])
   {
-    //we compute our distance table one cell further than the inflation radius dictates so we can make the check below
+    // we compute our distance table one cell further than the inflation radius dictates so we can make the check below
     double distance = distanceLookup(mx, my, src_x, src_y);
 
-    //we only want to put the cell in the queue if it is within the inflation radius of the obstacle point
+    // const double dx = src_x - mx;
+    // const double dy = src_y - my;
+    // const double distance = dx*dx+dy*dy;
+
+    // we only want to put the cell in the queue if it is within the inflation radius of the obstacle point
     if (distance > cell_inflation_radius_)
       return;
 
-    //assign the cost associated with the distance from an obstacle to the cell
+    // assign the cost associated with the distance from an obstacle to the cell
     unsigned char cost = costLookup(mx, my, src_x, src_y);
     unsigned char old_cost = grid[index];
 
@@ -205,7 +524,7 @@ inline void InflationLayer::enqueue(unsigned char* grid, unsigned int index, uns
       grid[index] = cost;
     else
       grid[index] = std::max(old_cost, cost);
-    //push the cell data onto the queue and mark
+    // push the cell data onto the queue and mark
     seen_[index] = true;
     CellData data(distance, index, mx, my, src_x, src_y);
     inflation_queue_.push(data);
@@ -214,14 +533,13 @@ inline void InflationLayer::enqueue(unsigned char* grid, unsigned int index, uns
 
 void InflationLayer::computeCaches()
 {
-  if(cell_inflation_radius_ == 0)
+  if (cell_inflation_radius_ == 0)
     return;
 
-  //based on the inflation radius... compute distance and cost caches
-  if(cell_inflation_radius_ != cached_cell_inflation_radius_)
+  // based on the inflation radius... compute distance and cost caches
+  if (cell_inflation_radius_ != cached_cell_inflation_radius_)
   {
-    if(cached_cell_inflation_radius_ > 0)
-      deleteKernels();
+    deleteKernels();
 
     cached_costs_ = new unsigned char*[cell_inflation_radius_ + 2];
     cached_distances_ = new double*[cell_inflation_radius_ + 2];
@@ -246,6 +564,21 @@ void InflationLayer::computeCaches()
       cached_costs_[i][j] = computeCost(cached_distances_[i][j]);
     }
   }
+
+  // Build costmap representing the inflation about a lethal point
+  // This is used in the updateCost with Overlays method
+  {
+    const unsigned int n = cell_inflation_radius_;
+    const unsigned int cnx = 2 * n + 1;
+    const unsigned int cny = 2 * n + 1;
+    cached_kernel_.reset(new Costmap2D(cnx, cny, getResolution(), 0, 0, FREE_SPACE));
+
+    cached_kernel_->setCost(n, n, LETHAL_OBSTACLE);
+    cached_kernel_cnx_ = n;
+    cached_kernel_cny_ = n;
+
+    cached_kernel_inflated_ = false;
+  }
 }
 
 void InflationLayer::deleteKernels()
@@ -254,19 +587,25 @@ void InflationLayer::deleteKernels()
   {
     for (unsigned int i = 0; i <= cached_cell_inflation_radius_ + 1; ++i)
     {
-      delete[] cached_distances_[i];
+      if (cached_distances_[i])
+        delete[] cached_distances_[i];
     }
-    delete[] cached_distances_;
+    if (cached_distances_)
+      delete[] cached_distances_;
+    cached_distances_ = NULL;
   }
 
   if (cached_costs_ != NULL)
   {
     for (unsigned int i = 0; i <= cached_cell_inflation_radius_ + 1; ++i)
     {
-      delete[] cached_costs_[i];
+      if (cached_costs_[i])
+        delete[] cached_costs_[i];
     }
-    delete[] cached_costs_;
+    if (cached_costs_)
+      delete[] cached_costs_;
+    cached_costs_ = NULL;
   }
 }
 
-} // end namespace costmap_2d
+}  // namespace costmap_2d

--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -1,5 +1,42 @@
-#include<costmap_2d/static_layer.h>
-#include<costmap_2d/costmap_math.h>
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2008, 2013, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Eitan Marder-Eppstein
+ *         David V. Lu!!
+ *********************************************************************/
+#include <costmap_2d/static_layer.h>
+#include <costmap_2d/costmap_math.h>
 #include <pluginlib/class_list_macros.h>
 
 PLUGINLIB_EXPORT_CLASS(costmap_2d::StaticLayer, costmap_2d::Layer)
@@ -22,7 +59,9 @@ StaticLayer::~StaticLayer()
 void StaticLayer::onInitialize()
 {
   ros::NodeHandle nh("~/" + name_), g_nh;
-  current_ = true;
+
+  // Map is not current until it has been updated with static map
+  current_ = false;
 
   global_frame_ = layered_costmap_->getGlobalFrameID();
 
@@ -147,6 +186,8 @@ void StaticLayer::incomingMap(const nav_msgs::OccupancyGridConstPtr& new_map)
   height_ = size_y_;
   map_received_ = true;
   has_updated_data_ = true;
+
+//  markMapChanged(); // for internal caches
 }
 
 void StaticLayer::incomingUpdate(const map_msgs::OccupancyGridUpdateConstPtr& update)
@@ -166,6 +207,8 @@ void StaticLayer::incomingUpdate(const map_msgs::OccupancyGridUpdateConstPtr& up
     width_ = update->width;
     height_ = update->height;
     has_updated_data_ = true;
+
+//    markMapChanged(); // for internal caches
 }
 
 void StaticLayer::activate()
@@ -187,7 +230,7 @@ void StaticLayer::reset()
 }
 
 void StaticLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
-                                        double* max_x, double* max_y)
+                               double* max_x, double* max_y)
 {
   if (!map_received_ || !(has_updated_data_ || has_extra_bounds_))
     return;
@@ -206,16 +249,40 @@ void StaticLayer::updateBounds(double robot_x, double robot_y, double robot_yaw,
   
   has_updated_data_ = false;
 
+//  markMapChanged();
 }
 
-void StaticLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j)
+void StaticLayer::updateCosts(LayerActions* layer_actions, costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j)
 {
   if (!map_received_)
     return;
-  if(!use_maximum_)
-      updateWithTrueOverwrite(master_grid, min_i, min_j, max_i, max_j);
+
+  if (!use_maximum_)
+  {
+    updateWithTrueOverwrite(master_grid, min_i, min_j, max_i, max_j);
+
+    if(layer_actions)
+      layer_actions->addAction(
+            AABB(min_i, min_j, max_i, max_j),
+            this,
+            AABB(min_i, min_j, max_i, max_j),
+            &master_grid,
+            LayerActions::TRUEOVERWRITE,
+            __FILE__, __LINE__);
+  }
   else
-      updateWithMax(master_grid, min_i, min_j, max_i, max_j);
+  {
+    updateWithMax(master_grid, min_i, min_j, max_i, max_j);
+    if(layer_actions)
+      layer_actions->addAction(
+            AABB(min_i, min_j, max_i, max_j),
+            this,
+            AABB(min_i, min_j, max_i, max_j),
+            &master_grid,
+            LayerActions::MAX,
+            __FILE__, __LINE__);
+  }
+  current_ = true;
 }
 
-}
+}  // namespace costmap_2d

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -1,3 +1,40 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2008, 2013, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Eitan Marder-Eppstein
+ *         David V. Lu!!
+ *********************************************************************/
 #include <costmap_2d/voxel_layer.h>
 #include <pluginlib/class_list_macros.h>
 #include <pcl_conversions/pcl_conversions.h>
@@ -67,6 +104,12 @@ void VoxelLayer::reset()
   resetMaps();
   voxel_grid_.reset();
   activate();
+}
+
+void VoxelLayer::resetMaps()
+{
+  Costmap2D::resetMaps();
+  voxel_grid_.reset();
 }
 
 void VoxelLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x,
@@ -393,7 +436,6 @@ void VoxelLayer::updateOrigin(double new_origin_x, double new_origin_y)
   //make sure to clean up
   delete[] local_map;
   delete[] local_voxel_map;
-
 }
 
-}
+}  // namespace costmap_2d

--- a/costmap_2d/src/costmap_2d.cpp
+++ b/costmap_2d/src/costmap_2d.cpp
@@ -36,36 +36,62 @@
  *         David V. Lu!!
  *********************************************************************/
 #include <costmap_2d/costmap_2d.h>
+#include <costmap_2d/layer.h>
 #include <cstdio>
 
-using namespace std;
+#include <string>      // for string
+#include <algorithm>   // for min
+#include <vector>
 
 namespace costmap_2d
 {
 Costmap2D::Costmap2D(unsigned int cells_size_x, unsigned int cells_size_y, double resolution,
                      double origin_x, double origin_y, unsigned char default_value) :
-    size_x_(cells_size_x), size_y_(cells_size_y), resolution_(resolution), origin_x_(origin_x), 
-    origin_y_(origin_y), costmap_(NULL), default_value_(default_value)
+    size_x_(cells_size_x), size_y_(cells_size_y), resolution_(resolution), origin_x_(origin_x),
+  origin_y_(origin_y), costmap_(NULL), default_value_(default_value)
 {
   access_ = new boost::shared_mutex();
 
-  //create the costmap
+  // create the costmap
   initMaps(size_x_, size_y_);
   resetMaps();
 }
 
 void Costmap2D::deleteMaps()
 {
-  //clean up data
+  // clean up data
   boost::unique_lock < boost::shared_mutex > lock(*access_);
-  delete[] costmap_;
+  if (costmap_)
+    delete[] costmap_;
+  costmap_ = NULL;
 }
-
 void Costmap2D::initMaps(unsigned int size_x, unsigned int size_y)
 {
   boost::unique_lock < boost::shared_mutex > lock(*access_);
+  if (costmap_)
+    delete[] costmap_;
   costmap_ = new unsigned char[size_x * size_y];
 }
+
+
+sp_Costmap2D Costmap2D::addNamedCostmap2D(const std::string& map_name, sp_Costmap2D map)
+{
+  child_maps_[map_name] = map;
+  return map;
+}
+
+sp_Costmap2D Costmap2D::addNamedCostmap2D(sp_Costmap2D map, const std::string &map_name)
+{
+  return addNamedCostmap2D(map_name, map);
+}
+
+sp_Costmap2D Costmap2D::getNamedCostmap2D(const std::string &map_name)
+{
+  if (child_maps_.find(map_name) == child_maps_.end())
+    return sp_Costmap2D();  // NULL pointer
+  return child_maps_[map_name];
+}
+
 
 void Costmap2D::resizeMap(unsigned int size_x, unsigned int size_y, double resolution,
                           double origin_x, double origin_y)
@@ -82,6 +108,61 @@ void Costmap2D::resizeMap(unsigned int size_x, unsigned int size_y, double resol
   resetMaps();
 }
 
+void Costmap2D::copyCellsTo(Costmap2D& costmap, unsigned int src_x0, unsigned int src_y0,
+                                                unsigned int dst_x0, unsigned int dst_y0,
+                                                unsigned int xn,     unsigned int yn) const
+{
+  unsigned char* src = getCharMap();
+  unsigned char* dst = costmap.getCharMap();
+
+  if (!src || !dst)
+    return;
+
+  unsigned int src_nx = getSizeInCellsX();
+  unsigned int src_ny = getSizeInCellsY();
+
+  unsigned int dst_nx = costmap.getSizeInCellsX();
+  unsigned int dst_ny = costmap.getSizeInCellsY();
+
+  // if copy range goes out of bounds then truncate them
+  if (src_x0 + xn > src_nx) xn = src_nx - src_x0;
+  if (dst_x0 + xn > dst_nx) xn = dst_nx - dst_x0;
+  if (src_y0 + yn > src_ny) yn = src_ny - src_y0;
+  if (dst_y0 + yn > dst_ny) yn = dst_ny - dst_y0;
+
+  // copy each line of data
+  for (int y = 0; y < yn; y++)
+    memcpy(dst + y * dst_nx + dst_x0, src + y * src_nx + src_x0, xn);
+}
+
+void Costmap2D::copyCellsTo(sp_Costmap2D map, unsigned int src_x0, unsigned int src_y0,
+                            unsigned int dst_x0, unsigned int dst_y0,
+                            unsigned int xn, unsigned int yn) const
+{
+  if (map.get())
+    copyCellsTo(*map.get(), src_x0, src_y0, dst_x0, dst_y0, xn, yn);
+}
+
+void Costmap2D::copyCellsTo(Costmap2D &map, unsigned int x0, unsigned int y0, unsigned int xn, unsigned int yn) const
+{
+  copyCellsTo(map, x0, y0, x0, y0, xn, yn);
+}
+
+void Costmap2D::copyCellsTo(sp_Costmap2D map, unsigned int x0, unsigned int y0, unsigned int xn, unsigned int yn) const
+{
+  copyCellsTo(map, x0, y0, x0, y0, xn, yn);
+}
+
+void Costmap2D::copyCellsTo(Costmap2D &map) const
+{
+  copyCellsTo(map, 0, 0, 0, 0, getSizeInCellsX(), getSizeInCellsY());
+}
+
+void Costmap2D::copyCellsTo(sp_Costmap2D map) const
+{
+  copyCellsTo(map, 0, 0, 0, 0, getSizeInCellsX(), getSizeInCellsY());
+}
+
 void Costmap2D::resetMaps()
 {
   boost::unique_lock < boost::shared_mutex > lock(*access_);
@@ -90,26 +171,41 @@ void Costmap2D::resetMaps()
 
 void Costmap2D::resetMap(unsigned int x0, unsigned int y0, unsigned int xn, unsigned int yn)
 {
+  resetMap(x0, y0, xn, yn, getDefaultValue());
+}
+
+void Costmap2D::resetMap()
+{
+  resetMap(0, 0, getSizeInCellsX(), getSizeInCellsY(), getDefaultValue());
+}
+
+void Costmap2D::resetMap(unsigned int x0, unsigned int y0, unsigned int xn, unsigned int yn, const unsigned char value)
+{
   boost::unique_lock < boost::shared_mutex > lock(*(access_));
   unsigned int len = xn - x0;
   for (unsigned int y = y0 * size_x_ + x0; y < yn * size_x_ + x0; y += size_x_)
-    memset(costmap_ + y, default_value_, len * sizeof(unsigned char));
+    memset(costmap_ + y, value, len * sizeof(unsigned char));
+}
+
+void Costmap2D::resetMap(const unsigned char value)
+{
+  resetMap(0, 0, getSizeInCellsX(), getSizeInCellsY(), value);
 }
 
 bool Costmap2D::copyCostmapWindow(const Costmap2D& map, double win_origin_x, double win_origin_y, double win_size_x,
                                   double win_size_y)
 {
-  //check for self windowing
+  // check for self windowing
   if (this == &map)
   {
     // ROS_ERROR("Cannot convert this costmap into a window of itself");
     return false;
   }
 
-  //clean up old data
+  // clean up old data
   deleteMaps();
 
-  //compute the bounds of our new map
+  // compute the bounds of our new map
   unsigned int lower_left_x, lower_left_y, upper_right_x, upper_right_y;
   if (!map.worldToMap(win_origin_x, win_origin_y, lower_left_x, lower_left_y)
       || !map.worldToMap(win_origin_x + win_size_x, win_origin_y + win_size_y, upper_right_x, upper_right_y))
@@ -124,22 +220,32 @@ bool Costmap2D::copyCostmapWindow(const Costmap2D& map, double win_origin_x, dou
   origin_x_ = win_origin_x;
   origin_y_ = win_origin_y;
 
-  //initialize our various maps and reset markers for inflation
+  // initialize our various maps and reset markers for inflation
   initMaps(size_x_, size_y_);
 
-  //copy the window of the static map and the costmap that we're taking
+  // copy the window of the static map and the costmap that we're taking
   copyMapRegion(map.costmap_, lower_left_x, lower_left_y, map.size_x_, costmap_, 0, 0, size_x_, size_x_, size_y_);
   return true;
 }
 
+sp_Costmap2D Costmap2D::reducedResolutionCopy(int factor)
+{
+  return sp_Costmap2D(
+        new Costmap2D( (getSizeInCellsX()  + (factor-1)) / factor,
+                        (getSizeInCellsY()  + (factor-1)) / factor,
+                        getResolution() * factor,
+                        getOriginX(),
+                        getOriginY(),
+                        getDefaultValue() ) );
+}
+
 Costmap2D& Costmap2D::operator=(const Costmap2D& map)
 {
-
-  //check for self assignement
+  // check for self assignement
   if (this == &map)
     return *this;
 
-  //clean up old data
+  // clean up old data
   deleteMaps();
 
   size_x_ = map.size_x_;
@@ -148,10 +254,10 @@ Costmap2D& Costmap2D::operator=(const Costmap2D& map)
   origin_x_ = map.origin_x_;
   origin_y_ = map.origin_y_;
 
-  //initialize our various maps
+  // initialize our various maps
   initMaps(size_x_, size_y_);
 
-  //copy the cost map
+  // copy the cost map
   memcpy(costmap_, map.costmap_, size_x_ * size_y_ * sizeof(unsigned char));
 
   return *this;
@@ -163,7 +269,7 @@ Costmap2D::Costmap2D(const Costmap2D& map) :
   *this = map;
 }
 
-//just initialize everything to NULL by default
+// just initialize everything to NULL by default
 Costmap2D::Costmap2D() :
     size_x_(0), size_y_(0), resolution_(0.0), origin_x_(0.0), origin_y_(0.0), costmap_(NULL)
 {
@@ -177,7 +283,7 @@ Costmap2D::~Costmap2D()
 
 unsigned int Costmap2D::cellDistance(double world_dist)
 {
-  double cells_dist = max(0.0, ceil(world_dist / resolution_));
+  double cells_dist = std::max(0.0, ceil(world_dist / resolution_));
   return (unsigned int)cells_dist;
 }
 
@@ -191,9 +297,20 @@ unsigned char Costmap2D::getCost(unsigned int mx, unsigned int my) const
   return costmap_[getIndex(mx, my)];
 }
 
+
+unsigned char Costmap2D::getCost(unsigned int idx) const
+{
+  return costmap_[idx];
+}
+
 void Costmap2D::setCost(unsigned int mx, unsigned int my, unsigned char cost)
 {
-  costmap_[getIndex(mx, my)] = cost;
+  setCost(getIndex(mx, my), cost);
+}
+
+void Costmap2D::setCost(unsigned int index, unsigned char cost)
+{
+  costmap_[index] = cost;
 }
 
 void Costmap2D::mapToWorld(unsigned int mx, unsigned int my, double& wx, double& wy) const
@@ -207,8 +324,8 @@ bool Costmap2D::worldToMap(double wx, double wy, unsigned int& mx, unsigned int&
   if (wx < origin_x_ || wy < origin_y_)
     return false;
 
-  mx = (int)((wx - origin_x_) / resolution_);
-  my = (int)((wy - origin_y_) / resolution_);
+  mx = static_cast<int>((wx - origin_x_) / resolution_);
+  my = static_cast<int>((wy - origin_y_) / resolution_);
 
   if (mx < size_x_ && my < size_y_)
     return true;
@@ -218,8 +335,8 @@ bool Costmap2D::worldToMap(double wx, double wy, unsigned int& mx, unsigned int&
 
 void Costmap2D::worldToMapNoBounds(double wx, double wy, int& mx, int& my) const
 {
-  mx = (int)((wx - origin_x_) / resolution_);
-  my = (int)((wy - origin_y_) / resolution_);
+  mx = static_cast<int>((wx - origin_x_) / resolution_);
+  my = static_cast<int>((wy - origin_y_) / resolution_);
 }
 
 void Costmap2D::worldToMapEnforceBounds(double wx, double wy, int& mx, int& my) const
@@ -227,87 +344,87 @@ void Costmap2D::worldToMapEnforceBounds(double wx, double wy, int& mx, int& my) 
   // Here we avoid doing any math to wx,wy before comparing them to
   // the bounds, so their values can go out to the max and min values
   // of double floating point.
-  if( wx < origin_x_ )
+  if ( wx < origin_x_ )
   {
     mx = 0;
   }
-  else if( wx > resolution_ * size_x_ + origin_x_ )
+  else if ( wx > resolution_ * size_x_ + origin_x_ )
   {
     mx = size_x_ - 1;
   }
   else
   {
-    mx = (int)((wx - origin_x_) / resolution_);
+    mx = static_cast<int>((wx - origin_x_) / resolution_);
   }
 
-  if( wy < origin_y_ )
+  if ( wy < origin_y_ )
   {
     my = 0;
   }
-  else if( wy > resolution_ * size_y_ + origin_y_ )
+  else if ( wy > resolution_ * size_y_ + origin_y_ )
   {
     my = size_y_ - 1;
   }
   else
   {
-    my = (int)((wy - origin_y_) / resolution_);
+    my = static_cast<int>((wy - origin_y_) / resolution_);
   }
 }
 
 void Costmap2D::updateOrigin(double new_origin_x, double new_origin_y)
 {
-  //project the new origin into the grid
+  // project the new origin into the grid
   int cell_ox, cell_oy;
-  cell_ox = int((new_origin_x - origin_x_) / resolution_);
-  cell_oy = int((new_origin_y - origin_y_) / resolution_);
+  cell_ox = static_cast<int>((new_origin_x - origin_x_) / resolution_);
+  cell_oy = static_cast<int>((new_origin_y - origin_y_) / resolution_);
 
-  //compute the associated world coordinates for the origin cell
-  //because we want to keep things grid-aligned
+  // compute the associated world coordinates for the origin cell
+  // because we want to keep things grid-aligned
   double new_grid_ox, new_grid_oy;
   new_grid_ox = origin_x_ + cell_ox * resolution_;
   new_grid_oy = origin_y_ + cell_oy * resolution_;
 
-  //To save casting from unsigned int to int a bunch of times
+  // To save casting from unsigned int to int a bunch of times
   int size_x = size_x_;
   int size_y = size_y_;
 
-  //we need to compute the overlap of the new and existing windows
+  // we need to compute the overlap of the new and existing windows
   int lower_left_x, lower_left_y, upper_right_x, upper_right_y;
-  lower_left_x = min(max(cell_ox, 0), size_x);
-  lower_left_y = min(max(cell_oy, 0), size_y);
-  upper_right_x = min(max(cell_ox + size_x, 0), size_x);
-  upper_right_y = min(max(cell_oy + size_y, 0), size_y);
+  lower_left_x = std::min(std::max(cell_ox, 0), size_x);
+  lower_left_y = std::min(std::max(cell_oy, 0), size_y);
+  upper_right_x = std::min(std::max(cell_ox + size_x, 0), size_x);
+  upper_right_y = std::min(std::max(cell_oy + size_y, 0), size_y);
 
   unsigned int cell_size_x = upper_right_x - lower_left_x;
   unsigned int cell_size_y = upper_right_y - lower_left_y;
 
-  //we need a map to store the obstacles in the window temporarily
+  // we need a map to store the obstacles in the window temporarily
   unsigned char* local_map = new unsigned char[cell_size_x * cell_size_y];
 
-  //copy the local window in the costmap to the local map
+  // copy the local window in the costmap to the local map
   copyMapRegion(costmap_, lower_left_x, lower_left_y, size_x_, local_map, 0, 0, cell_size_x, cell_size_x, cell_size_y);
 
-  //now we'll set the costmap to be completely unknown if we track unknown space
+  // now we'll set the costmap to be completely unknown if we track unknown space
   resetMaps();
 
-  //update the origin with the appropriate world coordinates
+  // update the origin with the appropriate world coordinates
   origin_x_ = new_grid_ox;
   origin_y_ = new_grid_oy;
 
-  //compute the starting cell location for copying data back in
+  // compute the starting cell location for copying data back in
   int start_x = lower_left_x - cell_ox;
   int start_y = lower_left_y - cell_oy;
 
-  //now we want to copy the overlapping information back into the map, but in its new location
+  // now we want to copy the overlapping information back into the map, but in its new location
   copyMapRegion(local_map, 0, 0, cell_size_x, costmap_, start_x, start_y, size_x_, cell_size_x, cell_size_y);
 
-  //make sure to clean up
+  // make sure to clean up
   delete[] local_map;
 }
 
 bool Costmap2D::setConvexPolygonCost(const std::vector<geometry_msgs::Point>& polygon, unsigned char cost_value)
 {
-  //we assume the polygon is given in the global_frame... we need to transform it to map coordinates
+  // we assume the polygon is given in the global_frame... we need to transform it to map coordinates
   std::vector<MapLocation> map_polygon;
   for (unsigned int i = 0; i < polygon.size(); ++i)
   {
@@ -322,10 +439,10 @@ bool Costmap2D::setConvexPolygonCost(const std::vector<geometry_msgs::Point>& po
 
   std::vector<MapLocation> polygon_cells;
 
-  //get the cells that fill the polygon
+  // get the cells that fill the polygon
   convexFillCells(map_polygon, polygon_cells);
 
-  //set the cost of those cells
+  // set the cost of those cells
   for (unsigned int i = 0; i < polygon_cells.size(); ++i)
   {
     unsigned int index = getIndex(polygon_cells[i].x, polygon_cells[i].y);
@@ -344,21 +461,21 @@ void Costmap2D::polygonOutlineCells(const std::vector<MapLocation>& polygon, std
   if (!polygon.empty())
   {
     unsigned int last_index = polygon.size() - 1;
-    //we also need to close the polygon by going from the last point to the first
+    // we also need to close the polygon by going from the last point to the first
     raytraceLine(cell_gatherer, polygon[last_index].x, polygon[last_index].y, polygon[0].x, polygon[0].y);
   }
 }
 
 void Costmap2D::convexFillCells(const std::vector<MapLocation>& polygon, std::vector<MapLocation>& polygon_cells)
 {
-  //we need a minimum polygon of a triangle
+  // we need a minimum polygon of a triangle
   if (polygon.size() < 3)
     return;
 
-  //first get the cells that make up the outline of the polygon
+  // first get the cells that make up the outline of the polygon
   polygonOutlineCells(polygon, polygon_cells);
 
-  //quick bubble sort to sort points by x
+  // quick bubble sort to sort points by x
   MapLocation swap;
   unsigned int i = 0;
   while (i < polygon_cells.size() - 1)
@@ -382,7 +499,7 @@ void Costmap2D::convexFillCells(const std::vector<MapLocation>& polygon, std::ve
   unsigned int min_x = polygon_cells[0].x;
   unsigned int max_x = polygon_cells[polygon_cells.size() - 1].x;
 
-  //walk through each column and mark cells inside the polygon
+  // walk through each column and mark cells inside the polygon
   for (unsigned int x = min_x; x <= max_x; ++x)
   {
     if (i >= polygon_cells.size() - 1)
@@ -410,13 +527,12 @@ void Costmap2D::convexFillCells(const std::vector<MapLocation>& polygon, std::ve
     }
 
     MapLocation pt;
-    //loop though cells in the column
+    // loop though cells in the column
     for (unsigned int y = min_pt.y; y < max_pt.y; ++y)
     {
       pt.x = x;
       pt.y = y;
       polygon_cells.push_back(pt);
-
     }
   }
 }
@@ -479,4 +595,4 @@ bool Costmap2D::saveMap(std::string file_name)
   return true;
 }
 
-}
+}  // namespace costmap_2d

--- a/costmap_2d/src/layer.cpp
+++ b/costmap_2d/src/layer.cpp
@@ -28,19 +28,24 @@
  */
 
 #include "costmap_2d/layer.h"
+#include <stdio.h>
+
+#include <string>     // for string
+#include <algorithm>  // for min
+#include <vector>     // for vector<>
 
 namespace costmap_2d
 {
 
 Layer::Layer()
-  : layered_costmap_( NULL )
-  , current_( false )
-  , enabled_( false )
+  : layered_costmap_(NULL)
+  , current_(false)
+  , enabled_(false)
   , name_()
   , tf_(NULL)
 {}
 
-void Layer::initialize( LayeredCostmap* parent, std::string name, tf::TransformListener *tf )
+void Layer::initialize(LayeredCostmap* parent, std::string name, tf::TransformListener *tf)
 {
   layered_costmap_ = parent;
   name_ = name;
@@ -48,9 +53,441 @@ void Layer::initialize( LayeredCostmap* parent, std::string name, tf::TransformL
   onInitialize();
 }
 
+
 const std::vector<geometry_msgs::Point>& Layer::getFootprint() const
 {
   return layered_costmap_->getFootprint();
 }
 
-} // end namespace costmap_2d
+void LayerActions::addAction(const AABB& r, Costmap2D* map, LayerActions::Action a, const char *file, unsigned int line)
+{
+  v_actions.push_back(a);
+
+  // we either don't know the source map or there is no source map
+  // for instance, the footprint source is a polygon that gets written
+  v_source_maps.push_back(0);
+  v_source_rect.push_back(AABB());
+
+  v_destination_maps.push_back(map);
+  v_destination_rect.push_back(AABB(r));
+
+  v_action_file.push_back(std::string(file));
+  v_action_line.push_back(line);
+}
+
+void LayerActions::addAction(const AABB& src_rect, Costmap2D* src_map,
+                             const AABB& dst_rect, Costmap2D* dst_map,
+                             LayerActions::Action a, const char *file, unsigned int line)
+{
+  v_actions.push_back(a);
+
+  v_source_maps.push_back(src_map);
+  v_source_rect.push_back(src_rect);
+
+  v_destination_maps.push_back(dst_map);
+  v_destination_rect.push_back(dst_rect);
+
+  v_action_file.push_back(std::string(file));
+  v_action_line.push_back(line);
+}
+
+void LayerActions::clear()
+{
+  v_actions.clear();
+  v_source_maps.clear();
+  v_source_rect.clear();
+  v_destination_maps.clear();
+  v_destination_rect.clear();
+
+  v_action_file.clear();
+  v_action_file.clear();
+}
+
+void LayerActions::copyTo(LayerActions& la_dest)
+{
+  la_dest.clear();
+
+  const int n = v_actions.size();
+  for (int i = 0; i < n; i++)
+  {
+    appendActionTo(la_dest, i);
+  }
+}
+
+void LayerActions::appendActionTo(LayerActions &la_dest, int action_index)
+{
+  la_dest.v_actions.push_back(v_actions[action_index]);
+  la_dest.v_source_maps.push_back(v_source_maps[action_index]);
+  la_dest.v_source_rect.push_back(v_source_rect[action_index]);
+  la_dest.v_destination_maps.push_back(v_destination_maps[action_index]);
+  la_dest.v_destination_rect.push_back(v_destination_rect[action_index]);
+
+  la_dest.v_action_file.push_back(v_action_file[action_index]);
+  la_dest.v_action_line.push_back(v_action_line[action_index]);
+}
+
+void LayerActions::copyToWithMatchingDest(LayerActions &la_dest, Costmap2D *match_pattern)
+{
+  la_dest.clear();
+
+  const int n = v_actions.size();
+  for (int i = 0; i < n; i++)
+  {
+    if (v_destination_maps[i] == match_pattern)
+      appendActionTo(la_dest, i);
+  }
+}
+
+LayerActions::Action LayerActions::actionAt(int idx)
+{
+  if (validIndex(idx))
+    return v_actions[idx];
+  return NONE;
+}
+
+bool LayerActions::actionIs(int idx, LayerActions::Action a)
+{
+  return actionAt(idx) == a;
+}
+
+bool LayerActions::validIndex(int idx)
+{
+  return idx >= 0 && idx < size();
+}
+
+Costmap2D* LayerActions::destinationCostmapAt(int idx)
+{
+  if (validIndex(idx))
+    return v_destination_maps[idx];
+  return 0;
+}
+
+Costmap2D* LayerActions::sourceCostmapAt(int idx)
+{
+  if (validIndex(idx))
+    return v_source_maps[idx];
+  return 0;
+}
+
+const AABB& LayerActions::sourceAABBAt(int idx)
+{
+  if (validIndex(idx))
+    return v_source_rect[idx];
+  return nullAABB;
+}
+
+const AABB& LayerActions::destinationAABBAt(int idx)
+{
+  if (validIndex(idx))
+    return v_destination_rect[idx];
+  return nullAABB;
+}
+
+// looking to merge sets of actions that occur in the same space
+void LayerActions::optimize(int tol)
+{
+  const int n = v_actions.size();
+
+  if (!n)
+    return;  // no work to do
+
+  std::vector<bool> got_it;  // if this data is in our new list
+  got_it.resize(n, false);
+
+  LayerActions mergedActions;
+
+  // looking to merge changes: MODIFYs, MAXs and OVERWRITEs
+  // will not merge TRUEOVERWITES
+  for (int i = 0; i < n; i++)
+  {
+    if (!got_it[i])
+    {
+      got_it[i] = true;  // don't need to consider this any more
+      AABB merged_rect = AABB(v_destination_rect[i]);
+
+      if (v_actions[i] != TRUEOVERWRITE)  // then we can look to merge it
+      {
+        for (int j = 0; j < n; j++)
+        {
+          // making sure the actions we are looking to merge operate on the same Costmap2D
+          if (v_destination_maps[i] == v_destination_maps[j])
+          {
+            if (!got_it[j])  // then we can consider this
+            {
+              const AABB& aabb_j = v_destination_rect[j];
+              if (merged_rect.intersect(aabb_j, tol))
+              {
+                merged_rect.expandBoundingBox(aabb_j);
+                got_it[j] = true;  // this is now covered in the merged AABB
+              }
+            }
+          }
+        }
+      }
+
+      // now we have an updated representation of the rectangle.
+      // adding it to the merged list
+      mergedActions.addAction(merged_rect, v_destination_maps[i], v_actions[i],
+                              v_action_file[i].c_str(), v_action_line[i]);
+    }
+  }
+  // now have a list of updated actions
+}
+
+
+
+static void _snprintRectCM(char* buf, int n, const AABB& r, Costmap2D* cm)
+{
+  if (cm)
+  {
+    // 57 characters:
+    snprintf(buf, n, "Cosmap2D(%p) [ (%6d,%6d), (%6d,%6d) ]",
+                      reinterpret_cast<void*>(cm), r.min_x, r.min_y, r.max_x, r.max_y);
+  }
+  else
+  {
+    snprintf(buf, n, "%57s", "Non-Costmap2D data");
+  }
+}
+
+void LayerActions::writeToFile(const char *filename)
+{
+  FILE* f = fopen(filename, "w");
+  if (!f)
+    return;
+
+  fprintf(f, "LayerActions (%p)\n", reinterpret_cast<void*>(this));
+  const int n = v_actions.size();
+
+  char buf[64];
+
+  for (int i = 0; i < n; i++)
+  {
+    fprintf(f, "(%s:%04i):\n", v_action_file[i].c_str(), v_action_line[i]);
+
+    switch (v_actions[i])
+    {
+      case OVERWRITE:     fprintf(f, "%13s ", "OVERWRITE"); break;
+      case TRUEOVERWRITE: fprintf(f, "%13s ", "TRUEOVERWRITE"); break;
+      case MODIFY:        fprintf(f, "%13s ", "MODIFY"); break;
+      case MAX:           fprintf(f, "%13s ", "MAX"); break;
+    }
+
+    _snprintRectCM(buf, 64, v_source_rect[i], v_source_maps[i]);
+    fprintf(f, "%s", buf);
+    fprintf(f, " => ");
+    _snprintRectCM(buf, 64, v_destination_rect[i], v_destination_maps[i]);
+    fprintf(f, "%s", buf);
+    fprintf(f, "\n");
+  }
+
+  fclose(f);
+}
+
+AABB::AABB()
+  : min_x(0), max_x(0), min_y(0), max_y(0), initialized_(false)
+{
+}
+
+AABB::AABB(const AABB &r)
+{
+  r.copyTo(*this);
+}
+
+bool AABB::same(const AABB &r, int tol)
+{
+  if (!initialized() || !r.initialized())
+    return false;
+  if (tol)
+  {
+    if (abs(r.min_x - min_x) > tol) return false;
+    if (abs(r.min_y - min_y) > tol) return false;
+    if (abs(r.max_x - max_x) > tol) return false;
+    if (abs(r.max_y - max_y) > tol) return false;
+    return true;
+  }
+  if (r.min_x != min_x) return false;
+  if (r.min_y != min_y) return false;
+  if (r.max_x != max_x) return false;
+  if (r.max_y != max_y) return false;
+  return true;
+}
+
+void AABB::copyTo(AABB &dst) const
+{
+  dst.min_x = min_x;
+  dst.min_y = min_y;
+  dst.max_x = max_x;
+  dst.max_y = max_y;
+  dst.setInitialized(initialized());
+}
+
+AABB::AABB(int px, int py)
+{
+  initialized_ = true;
+  min_x = px;
+  min_y = py;
+  max_x = px;
+  max_y = py;
+}
+
+AABB::AABB(int px1, int py1, int px2, int py2)
+{
+  initialized_ = true;
+  min_x = std::min(px1, px2);
+  max_x = std::max(px1, px2);
+  min_y = std::min(py1, py2);
+  max_y = std::max(py1, py2);
+}
+
+
+void AABB::expandBoundingBox(const AABB &r)
+{
+  if (initialized_)
+  {
+    min_x = std::min(min_x, r.min_x);
+    max_x = std::max(max_x, r.max_x);
+    min_y = std::min(min_y, r.min_y);
+    max_y = std::max(max_y, r.max_y);
+  }
+  else
+  {
+    r.copyTo(*this);
+  }
+}
+
+void AABB::expandBoundingBox(int r)
+{
+  if (initialized_)
+  {
+    min_x -= r;
+    min_y -= r;
+    max_x += r;
+    max_y += r;
+  }
+}
+
+bool AABB::inside(int px, int py, int margin) const
+{
+  if (px < min_x+margin) return false;
+  if (px > max_x-margin) return false;
+  if (py < min_y+margin) return false;
+  if (py > max_y-margin) return false;
+  return true;
+}
+
+bool AABB::inside(const AABB& bb, int margin) const
+{
+  return
+      inside(bb.min_x, bb.min_y, margin) &&
+      inside(bb.max_x, bb.max_y, margin);
+}
+
+void AABB::clip(const AABB &bb, AABB &clipped) const
+{
+  bb.copyTo(clipped);
+  clipped.min_x = std::max(min_x, clipped.min_x);
+  clipped.min_y = std::max(min_y, clipped.min_y);
+  clipped.max_x = std::min(max_x, clipped.max_x);
+  clipped.max_y = std::min(max_y, clipped.max_y);
+
+  clipped.clampBounds();
+}
+
+void AABB::clampBounds()
+{
+  if (max_x < min_x)
+    max_x = min_x;
+  if (max_y < min_y)
+    max_y = min_y;
+}
+
+double AABB::ratioInside(const AABB &bb) const
+{
+  AABB clipped;
+  clip(bb, clipped);
+
+  return static_cast<double>(area()) / static_cast<double>(clipped.area());
+}
+
+int AABB::area() const
+{
+  if (!initialized_)
+    return 0;
+
+  return (max_x - min_x) * (max_y - min_y);
+}
+
+int AABB::xn() const
+{
+  if (!initialized_)
+    return 0;
+  return max_x - min_x;
+}
+
+int AABB::yn() const
+{
+  if (!initialized_)
+    return 0;
+  return max_y - min_y;
+}
+
+bool AABB::intersect(const AABB &bb, int margin) const
+{
+  margin *= 2;  // since margin applied to both
+  if (bb.max_x + margin < min_x) return false;
+  if (bb.min_x - margin > max_x) return false;
+  if (bb.max_y + margin < min_y) return false;
+  if (bb.min_y - margin > max_y) return false;
+  return true;
+}
+
+void AABB::mergeIntersecting(std::vector<AABB> &vec_aabb, int margin)
+{
+  const int n = vec_aabb.size();
+  std::vector<AABB> cpy;
+  for (int i = 0; i < n; i++)
+    cpy.push_back(vec_aabb.at(i));
+  vec_aabb.clear();
+
+  std::vector<bool> got_it;  // if this data is in our new list
+  got_it.resize(n, false);
+
+  for (int i = 0; i < n; i++)
+  {
+    if (!got_it[i])
+    {
+      AABB bb = cpy[i];
+      got_it[i] = true;
+
+      for (int j = i+1; j < n; j++)
+      {
+        if (!got_it[j])
+        {
+          if (bb.intersect(cpy[j], margin))
+          {
+            bb.expandBoundingBox(cpy[j]);
+            got_it[j] = true;
+          }
+        }
+      }
+      vec_aabb.push_back(bb);
+    }
+  }
+}
+
+int AABB::x0() const
+{
+  if (!initialized_)
+    return 0;
+  return min_x;
+}
+
+int AABB::y0() const
+{
+  if (!initialized_)
+    return 0;
+  return min_y;
+}
+
+}  // end namespace costmap_2d

--- a/costmap_2d/src/observation_buffer.cpp
+++ b/costmap_2d/src/observation_buffer.cpp
@@ -141,6 +141,7 @@ void ObservationBuffer::bufferCloud(const pcl::PointCloud<pcl::PointXYZ>& cloud)
   {
     //given these observations come from sensors... we'll need to store the origin pt of the sensor
     Stamped < tf::Vector3 > local_origin(tf::Vector3(0, 0, 0), pcl_conversions::fromPCL(cloud.header).stamp, origin_frame);
+    tf_.waitForTransform(global_frame_, local_origin.frame_id_, local_origin.stamp_, ros::Duration(0.5));
     tf_.transformPoint(global_frame_, local_origin, global_origin);
     observation_list_.front().origin_.x = global_origin.getX();
     observation_list_.front().origin_.y = global_origin.getY();


### PR DESCRIPTION
The main changes to the Costmap2D involve the tracking of where each plugin makes changes to the master_grid in their updateCosts methods. 

Using these changes we can make decisions about what needs to be inflated and what inflation data can be reused.

Costmaps now have the ability to store sub-costmaps by name. This is used to make caches of inflated 
data, for instance, the static map has a cache of it's inflated form. The master_grid also has a workspace sub-costmap to use as a buffer when building an inflated form from different sources (current master_grid data and cached inflated data).

2 Classes were added:
  AABB is an axis aligned bounding box and is used to record where layers make changes to the master_grid
  LayerActions stores a sequence of actions made up of source maps, destination maps, source locations, destination locations and action types.
