### PR TITLE
More aggressive locking around layered_costmap update map.

### DIFF
--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -80,7 +80,6 @@ void LayeredCostmap::resizeMap(unsigned int size_x, unsigned int size_y, double 
 
 void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
 {
-
   // if we're using a rolling buffer costmap... we need to update the origin using the robot's position
   if (rolling_window_)
   {
@@ -120,15 +119,13 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
     return;
 
   // non-locking reset Map:
-  {
-    unsigned char value = costmap_.getDefaultValue();
-    const int size_x_ = costmap_.getSizeInCellsX();
-    unsigned char* data = costmap_.getCharMap();
+  unsigned char value = costmap_.getDefaultValue();
+  const int size_x_ = costmap_.getSizeInCellsX();
+  unsigned char* data = costmap_.getCharMap();
 
-    unsigned int len = xn - x0;
-    for (unsigned int y = y0 * size_x_ + x0; y < yn * size_x_ + x0; y += size_x_)
-      memset(data + y, value, len * sizeof(unsigned char));
-  }
+  unsigned int len = xn - x0;
+  for (unsigned int y = y0 * size_x_ + x0; y < yn * size_x_ + x0; y += size_x_)
+    memset(data + y, value, len * sizeof(unsigned char));
 
   // we will record a list of actions taken on the costmaps so we can later
   // make decisions about what needs to be inflated and what does not.

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -80,6 +80,7 @@ void LayeredCostmap::resizeMap(unsigned int size_x, unsigned int size_y, double 
 
 void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
 {
+
   // if we're using a rolling buffer costmap... we need to update the origin using the robot's position
   if (rolling_window_)
   {
@@ -93,6 +94,10 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
 
   minx_ = miny_ = 1e30;
   maxx_ = maxy_ = -1e30;
+
+  // locking for the rest of the method:
+  // Cannot lock before updateOrigin as it used a locking resetMap
+  boost::unique_lock < boost::shared_mutex > lock(*(costmap_.getLock()));
 
   for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
       ++plugin)
@@ -114,14 +119,22 @@ void LayeredCostmap::updateMap(double robot_x, double robot_y, double robot_yaw)
   if (xn < x0 || yn < y0)
     return;
 
-  costmap_.resetMap(x0, y0, xn, yn);
+  // non-locking reset Map:
+  {
+    unsigned char value = costmap_.getDefaultValue();
+    const int size_x_ = costmap_.getSizeInCellsX();
+    unsigned char* data = costmap_.getCharMap();
+
+    unsigned int len = xn - x0;
+    for (unsigned int y = y0 * size_x_ + x0; y < yn * size_x_ + x0; y += size_x_)
+      memset(data + y, value, len * sizeof(unsigned char));
+  }
 
   // we will record a list of actions taken on the costmaps so we can later
   // make decisions about what needs to be inflated and what does not.
   LayerActions actions;
   
   {
-    boost::unique_lock < boost::shared_mutex > lock(*(costmap_.getLock()));
     for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
         ++plugin)
     {


### PR DESCRIPTION
Forgetting observations within the safety radius when there is evidence they are gone.