### PR TITLE
Tightened limit on upper range.

### DIFF
--- a/costmap_2d/src/costmap_2d.cpp
+++ b/costmap_2d/src/costmap_2d.cpp
@@ -294,8 +294,8 @@ void Costmap2D::setMapCost(unsigned int x0, unsigned int y0, unsigned int xn, un
   x0 = std::min(size_x_ - 1, x0);
   y0 = std::min(size_y_ - 1, y0);
 
-  xn = std::min(size_x_, xn);
-  yn = std::min(size_y_, yn);
+  xn = std::min(size_x_ - 1, xn);
+  yn = std::min(size_y_ - 1, yn);
   
   unsigned int len = xn - x0;
   for (unsigned int y = y0 * size_x_ + x0; y < yn * size_x_ + x0; y += size_x_)


### PR DESCRIPTION
I mistakenly thought xn/yn were the number of things in the x or y direction but they are part of the limits as in x_{0} to x_{n} inclusively. 

This required the same "inclusive" style bounds checks on the upper bound as the lower bound.

