### PR TITLE
Core 1735 map load mutexes

### DIFF
--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -367,6 +367,9 @@ void ObstacleLayer::poseConfidenceCallback(const std_msgs::Float64 &message)
 void ObstacleLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x,
                                           double* min_y, double* max_x, double* max_y)
 {
+  // we are making changes to the local costmap so we want to make sure others don't
+  boost::unique_lock<mutex_t> lock(*(getMutex()));
+
   if (use_forgetful_version_)
     return forgetfulUpdateBounds(robot_x, robot_y, robot_yaw, min_x, min_y, max_x, max_y);
 

--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -159,6 +159,7 @@ unsigned char StaticLayer::interpretValue(unsigned char value)
 
 void StaticLayer::incomingMap(const nav_msgs::OccupancyGridConstPtr& new_map)
 {
+  boost::unique_lock<mutex_t> lock(*(getMutex()));
   unsigned int size_x = new_map->info.width, size_y = new_map->info.height;
 
   ROS_DEBUG("Received a %d X %d map at %f m/pix", size_x, size_y, new_map->info.resolution);

--- a/costmap_2d/src/costmap_layer.cpp
+++ b/costmap_2d/src/costmap_layer.cpp
@@ -48,8 +48,17 @@ void CostmapLayer::updateWithMax(costmap_2d::Costmap2D& master_grid, int min_i, 
   if (!enabled_)
     return;
 
+  boost::unique_lock<mutex_t> lock_1(*(getMutex()));
+  boost::unique_lock<mutex_t> lock_2(*(master_grid.getMutex()));
+
   unsigned char* master_array = master_grid.getCharMap();
   unsigned int span = master_grid.getSizeInCellsX();
+
+  // make sure the map size hasn't changed while we waited on the locks
+  if (span != getSizeInCellsX())
+    return;
+  if( master_grid.getSizeInCellsY() != getSizeInCellsY())
+    return;
 
   for (int j = min_j; j < max_j; j++)
   {
@@ -74,8 +83,18 @@ void CostmapLayer::updateWithTrueOverwrite(costmap_2d::Costmap2D& master_grid, i
 {
   if (!enabled_)
     return;
+
+  boost::unique_lock<mutex_t> lock_1(*(getMutex()));
+  boost::unique_lock<mutex_t> lock_2(*(master_grid.getMutex()));
+
   unsigned char* master = master_grid.getCharMap();
   unsigned int span = master_grid.getSizeInCellsX();
+
+  // make sure the map size hasn't changed while we waited on the locks
+  if (span != getSizeInCellsX())
+    return;
+  if( master_grid.getSizeInCellsY() != getSizeInCellsY())
+    return;
 
   for (int j = min_j; j < max_j; j++)
   {
@@ -92,8 +111,18 @@ void CostmapLayer::updateWithOverwrite(costmap_2d::Costmap2D& master_grid, int m
 {
   if (!enabled_)
     return;
+
+  boost::unique_lock<mutex_t> lock_1(*(getMutex()));
+  boost::unique_lock<mutex_t> lock_2(*(master_grid.getMutex()));
+
   unsigned char* master = master_grid.getCharMap();
   unsigned int span = master_grid.getSizeInCellsX();
+
+  // make sure the map size hasn't changed while we waited on the locks
+  if (span != getSizeInCellsX())
+    return;
+  if( master_grid.getSizeInCellsY() != getSizeInCellsY())
+    return;
 
   for (int j = min_j; j < max_j; j++)
   {
@@ -111,8 +140,18 @@ void CostmapLayer::updateWithAddition(costmap_2d::Costmap2D& master_grid, int mi
 {
   if (!enabled_)
     return;
+
+  boost::unique_lock<mutex_t> lock_1(*(getMutex()));
+  boost::unique_lock<mutex_t> lock_2(*(master_grid.getMutex()));
+
   unsigned char* master_array = master_grid.getCharMap();
   unsigned int span = master_grid.getSizeInCellsX();
+
+  // make sure the map size hasn't changed while we waited on the locks
+  if (span != getSizeInCellsX())
+    return;
+  if( master_grid.getSizeInCellsY() != getSizeInCellsY())
+    return;
 
   for (int j = min_j; j < max_j; j++)
   {

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -69,6 +69,7 @@ LayeredCostmap::~LayeredCostmap()
 void LayeredCostmap::resizeMap(unsigned int size_x, unsigned int size_y, double resolution, double origin_x,
                                double origin_y, bool size_locked)
 {
+  boost::unique_lock<Costmap2D::mutex_t> lock(*(costmap_.getMutex()));
   size_locked_ = size_locked;
   costmap_.resizeMap(size_x, size_y, resolution, origin_x, origin_y);
   for (vector<boost::shared_ptr<Layer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();


### PR DESCRIPTION
This adds protection around areas where the costmap is being read from or written to. Before this it was easy to trigger a crash by quickly loading maps of various sizes. The costmap plugins would operate on data that would change size and end up seg-faulting. 

Note: The mutexes are now recursive mutexes so locking on the same one in a single thread is OK.

@skaynama 
@servos 
@paulbovbel 