### PR TITLE
Fixing minimum boundary value in the inflation layer's updateBounds method

### DIFF
--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -146,8 +146,8 @@ void InflationLayer::updateBounds(double robot_x, double robot_y, double robot_y
 {
   if (need_reinflation_)
   {
-    *min_x = -std::numeric_limits<double>::min();
-    *min_y = -std::numeric_limits<double>::min();
+    *min_x = -std::numeric_limits<double>::max();
+    *min_y = -std::numeric_limits<double>::max();
     *max_x = std::numeric_limits<double>::max();
     *max_y = std::numeric_limits<double>::max();
     need_reinflation_ = false;

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -146,8 +146,8 @@ void InflationLayer::updateBounds(double robot_x, double robot_y, double robot_y
 {
   if (need_reinflation_)
   {
-    *min_x = std::numeric_limits<double>::min();
-    *min_y = std::numeric_limits<double>::min();
+    *min_x = -std::numeric_limits<double>::min();
+    *min_y = -std::numeric_limits<double>::min();
     *max_x = std::numeric_limits<double>::max();
     *max_y = std::numeric_limits<double>::max();
     need_reinflation_ = false;


### PR DESCRIPTION
The layered costmap takes the minimum and maximum updated boundaries across all its member layers when updating its own boundaries. This prevents wasted computation but still ensures that all changes in constituent costmaps are reflected in the layered map. In the case of the inflation layer, if the inflation has never happened, the values in updateBounds should be set to the (-infinity, -infinity); (+infinity, +infinity), thereby forcing the entire layered costmap to update. This was attempted, but the code was using std::numeric_limits<double>::min() for -inifinity. For integer data types, this would work, but for doubles (the type being used), it returns the smallest positive value, which is a fraction larger than 0. This meant that we would only update the map from the map's origin to the boundaries, rather than the entire map. I changed the lower bounds to use -std::numeric_limits<double>::max().