### PR TITLE
Core 1788 obstacle pose confidence

### DIFF
--- a/costmap_2d/cfg/ObstaclePlugin.cfg
+++ b/costmap_2d/cfg/ObstaclePlugin.cfg
@@ -16,8 +16,8 @@ combo_enum = gen.enum([ gen.const("Overwrite", int_t,  0, "Overwrite values"),
 
 gen.add("combination_method", int_t, 0, "Method for combining two layers", 1, edit_method=combo_enum)
 
-gen.add("obstacle_lifespan", double_t, 0, "Number of seconds to remember an observations without proof", 10.0, 0, 3600.0)
-gen.add("obstacle_keep_radius", double_t, 0, "Radius within which no obstacles will be forgotten", 2.5, 0, 100)
+gen.add("obstacle_lifespan", double_t, 0, "Number of seconds to remember an observations without proof", 3.0, 0, 3600.0)
+gen.add("obstacle_keep_radius", double_t, 0, "Radius within which no obstacles will be forgotten", 1.7, 0, 100)
 gen.add("enable_forget", bool_t, 0, "If observations should be allowed to be forgotten", True)
 gen.add("pose_confidence_threshold", double_t, 0, "Pose confidence threshold below which obstacles are not remembered.", 0.7, 0, 1)
 

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -66,7 +66,7 @@ namespace costmap_2d
 {
 
 /// @brief Wall clock time, x and y coordinates in global reference frame
-typedef boost::tuple<double, double, double, unsigned int, unsigned int> TimeWorldPoint;
+typedef boost::tuple<double, double, double> TimeWorldPoint;
 
 class ObstacleLayer : public CostmapLayer
 {
@@ -148,6 +148,7 @@ protected:
    */
   void writeTimeWorldPoint(const TimeWorldPoint& p, unsigned char value,
                            double* min_x, double* min_y, double* max_x, double* max_y);
+
   virtual void setupDynamicReconfigure(ros::NodeHandle& nh);
 
   /**

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -66,7 +66,7 @@ namespace costmap_2d
 {
 
 /// @brief Wall clock time, x and y coordinates in global reference frame
-typedef boost::tuple<double, double, double> TimeWorldPoint;
+typedef boost::tuple<double, double, double, unsigned int, unsigned int> TimeWorldPoint;
 
 class ObstacleLayer : public CostmapLayer
 {
@@ -148,7 +148,6 @@ protected:
    */
   void writeTimeWorldPoint(const TimeWorldPoint& p, unsigned char value,
                            double* min_x, double* min_y, double* max_x, double* max_y);
-
   virtual void setupDynamicReconfigure(ros::NodeHandle& nh);
 
   /**

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -500,8 +500,18 @@ static bool sameTimeWorldPoints(const TimeWorldPoint& p1, const TimeWorldPoint& 
 void ObstacleLayer::writeTimeWorldPoint(const TimeWorldPoint &p, unsigned char value,
                                         double *min_x, double *min_y, double *max_x, double *max_y)
 {
-  setCost(p.get<3>(), p.get<4>(), value);
-  touch(p.get<1>(), p.get<2>(), min_x, min_y, max_x, max_y);
+  const double px = p.get<1>();
+  const double py = p.get<2>();
+
+  unsigned int mx, my;
+  if (!worldToMap(px, py, mx, my))
+  {
+    ROS_DEBUG("Computing map coords failed");
+    return;
+  }
+
+  setCost(mx, my, value);
+  touch(px, py, min_x, min_y, max_x, max_y);
 }
 
 void ObstacleLayer::updateFootprint(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
@@ -525,6 +535,9 @@ void ObstacleLayer::forgetfulUpdateBounds(double robot_x, double robot_y, double
     return;
   useExtraBounds(min_x, min_y, max_x, max_y);
 
+  // clear the costmap, it will get rewritten
+  resetMaps();
+  
   double layer_min_x = robot_x;
   double layer_max_x = robot_x;
   double layer_min_y = robot_y;
@@ -563,7 +576,6 @@ void ObstacleLayer::forgetfulUpdateBounds(double robot_x, double robot_y, double
 
     if(radius2 > obstacle_keep_radius2 && sample_time < earliest_epoch)
     {
-      writeTimeWorldPoint( it->second, FREE_SPACE, &layer_min_x, &layer_min_y, &layer_max_x, &layer_max_y);
       map_pending_erase_.push_back(it->first);
     }
   }
@@ -593,10 +605,21 @@ void ObstacleLayer::forgetfulUpdateBounds(double robot_x, double robot_y, double
   {
     TimeWorldPoint& p = it->second;
 
-    unsigned int index = getIndex(p.get<3>(), p.get<4>());
-    if (costmap_[index] == FREE_SPACE)
+    const double px = p.get<1>();
+    const double py = p.get<2>();
+
+    unsigned int mx, my;
+    if (!worldToMap(px, py, mx, my)) 
     {
       map_pending_erase_.push_back(it->first);
+    }
+    else
+    {
+      unsigned int index = getIndex(mx, my);
+      if (costmap_[index] == FREE_SPACE)
+      {
+        map_pending_erase_.push_back(it->first);
+      }
     }
   }
 
@@ -638,30 +661,33 @@ void ObstacleLayer::forgetfulUpdateBounds(double robot_x, double robot_y, double
         continue;
       }
 
-      unsigned int mx, my;
-      if (!worldToMap(px, py, mx, my))
+      TimeWorldPoint p(time_now, px, py);
+      writeTimeWorldPoint(p, LETHAL_OBSTACLE, &layer_min_x, &layer_min_y, &layer_max_x, &layer_max_y);
+
+      // if we have low pose confidence we will make sure this
+      // data gets cleared quickly by setting it's "birthday" to
+      // far in the past.
+      if(pose_confidence_ < pose_confidence_threshold_)
       {
-        ROS_DEBUG("Computing map coords failed");
+        p.get<0>() = time_now - obstacle_lifespan_;
       }
-      else
+
+      // remember this data
       {
-        TimeWorldPoint p(time_now, px, py, mx, my);
-        // if we have low pose confidence we will make sure this
-        // data gets cleared quickly by setting it's "birthday" to
-        // far in the past.
-        if(pose_confidence_ < pose_confidence_threshold_)
+        unsigned int mx, my;
+        if (!worldToMap(px, py, mx, my))
         {
-          p.get<0>() = time_now - obstacle_lifespan_;
+          ROS_DEBUG("Computing map coords failed");
         }
-        
-        writeTimeWorldPoint(p, LETHAL_OBSTACLE, &layer_min_x, &layer_min_y, &layer_max_x, &layer_max_y);
+        else
+        {
+          // remove data at location if it exists
+          std::pair<unsigned int, unsigned int> location(mx,my);
+          time_world_points_.erase(location);
 
-        // remove data at location if it exists
-        std::pair<unsigned int, unsigned int> location(mx,my);
-        time_world_points_.erase(location);
-
-        // insert new data
-        time_world_points_[location] = p;
+          // insert new data
+          time_world_points_[location] = p;
+        }
       }
     }
   }

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -673,21 +673,19 @@ void ObstacleLayer::forgetfulUpdateBounds(double robot_x, double robot_y, double
       }
 
       // remember this data
+      unsigned int mx, my;
+      if (!worldToMap(px, py, mx, my))
       {
-        unsigned int mx, my;
-        if (!worldToMap(px, py, mx, my))
-        {
-          ROS_DEBUG("Computing map coords failed");
-        }
-        else
-        {
-          // remove data at location if it exists
-          std::pair<unsigned int, unsigned int> location(mx,my);
-          time_world_points_.erase(location);
+        ROS_DEBUG("Computing map coords failed");
+      }
+      else
+      {
+        // remove data at location if it exists
+        std::pair<unsigned int, unsigned int> location(mx,my);
+        time_world_points_.erase(location);
 
-          // insert new data
-          time_world_points_[location] = p;
-        }
+        // insert new data
+        time_world_points_[location] = p;
       }
     }
   }


### PR DESCRIPTION
This PR fixes a regression where the code responsible for forgetting observations was not used if the pose confidence wasn't 1.0. 

Additions were made to allow proper clearing of old observations even when the robot is moving and discretization error could be a problem. This was done by clearing the internal buffer and only writing points we either see or remember.