### PR TITLE
Fix for planner failing after recovery behavior is executed.

### DIFF
--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -80,7 +80,7 @@ void InflationLayer::onInitialize()
   {
     boost::unique_lock < boost::shared_mutex > lock(*access_);
     ros::NodeHandle nh("~/" + name_), g_nh;
-    current_ = false; // This is new, blocks planners until all the calculations are complete
+    current_ = true;  // Make sure this is true so planners don't fail after layer reset (i.e. after recovery).
     if (seen_)
       delete[] seen_;
     seen_ = NULL;


### PR DESCRIPTION
Our recovery behavior has been failing due to this bug. The recovery behavior will call clearCostmapService which in turn calls resetLayers() in costmap2DRos. This ends up re-initializing each plugin layer. 

However, in Inflater_Layer, we set current_ = false during the initialization. Thus, after recovery, the planner will attempt to call move_base::makePlan, which checks each costmap layer for current_ = true. Since this fails, the planning will fail before even reaching SBPL. This is why our recovery should in theory never work atm, and why after failing the recovery, we can't issue a new path even when the robot is moved into the open.

@skaynama @jasonimercer 