### PR TITLE
CORE-3041: Removed logic that could prevent goal from ever being aborted

### DIFF
--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -967,14 +967,6 @@ namespace move_base {
         as_->setAborted(move_base_msgs::MoveBaseResult(), "Failed to pass global plan to the controller.");
         return true;
       }
-
-      //make sure to reset recovery_index_ since we were able to find a valid plan
-      if(recovery_trigger_ == PLANNING_R)
-      {
-        revertRecoveryChanges();
-        recovery_index_ = 0;
-        active_recovery_index_ = -1;
-      }
     }
 
     //the move_base state machine, handles the control logic for navigation


### PR DESCRIPTION
As a result strategy_manager would never know of the failed status of move_base.

I noticed that in certain scenarios (e.g. when an obstacle is placed on top of the goal) ```recovery_index_``` would prematurely get reset to 0. And so since ```recovery_index_``` would never exceed the recovery count the goal would never get aborted. This is bad because strategy_manager (while tasked to continuously resend the same goal for a period of time) needs to be made aware that we failed to get to the goal on these attempts.

The reason this happened is because in one of our recoveries we disable the obstacle_layer and so planning would succeed and the if block would get executed. Re-enabling the obstacle_layer immediatelt would cause the state machine to go into recovery directly from ```CONTROLLING``` but since ```recovery_index_``` was set back to 0 the very first recovery would get executed instead. And this would repeat forever.

I simply removed the if-block because we should only declare success (and reset ```recovery_index_``` to 0) if we've found a path AND we've been able to synthesize a ```cmd_vel```. There's a similar if block on line 1025 right after a successful return of ```computeVelocityCommands``` that does this so that should suffice.

@p6chen , @ayrton04  ( @jasonimercer only as FYI in case you're having too much fun on your vacation). Please review carefully as I intend to have this fix in 1.5.