### PR TITLE
Core 3163 move base goal manager

### DIFF
--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -48,6 +48,8 @@
 #include <nav_core/base_local_planner.h>
 #include <nav_core/base_global_planner.h>
 #include <nav_core/recovery_behavior.h>
+#include <nav_core/nav_goal_manager.h>
+
 #include <geometry_msgs/PoseStamped.h>
 #include <costmap_2d/costmap_2d_ros.h>
 #include <costmap_2d/costmap_2d.h>
@@ -282,6 +284,8 @@ namespace move_base {
       bool new_global_plan_;
 
       ros::Timer as_feedback_timer_;
+
+      nav_core::NavGoalMananger::Ptr goal_manager_;
   };
 };
 #endif

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -337,6 +337,7 @@ namespace move_base {
     move_base_msgs::MoveBaseActionGoal action_goal;
     action_goal.header.stamp = ros::Time::now();
     action_goal.goal.target_pose = *goal;
+    goal_manager_->setCurrentGoal(nav_core::NavGoal(*goal));
 
     action_goal_pub_.publish(action_goal);
   }
@@ -447,8 +448,6 @@ namespace move_base {
 
     //first try to make a plan to the exact desired goal
     std::vector<geometry_msgs::PoseStamped> global_plan;
-
-    goal_manager_->setCurrentGoal(nav_core::NavGoal(req.goal));
 
     // NOTE: The implementation of makePlan is responsible for locking the costmap
     if(!planner_->makePlan(start, req.goal, global_plan) || global_plan.empty()){
@@ -764,6 +763,7 @@ namespace move_base {
     }
 
     geometry_msgs::PoseStamped goal = goalToGlobalFrame(move_base_goal->target_pose);
+    goal_manager_->setCurrentGoal(nav_core::NavGoal(goal));
 
     //we have a goal so start the planner
     boost::unique_lock<boost::mutex> lock(planner_mutex_);
@@ -834,6 +834,8 @@ namespace move_base {
           last_oscillation_reset_ = ros::Time::now();
         }
         else {
+          goal_manager_->setActiveGoal(false);  // setting no active goal
+
           //if we've been preempted explicitly we need to shut things down
           resetState();
 

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -688,10 +688,15 @@ namespace move_base {
         // makePlan can take time. While planning, it's possible that we received a new goal. We should check for this
         // condition, and if it's true, we should carry on as if we did not succeed in planning this goal, which will
         // cause us to move on and re-start this thread for the new goal.
-        if (distanceXYTheta(planner_goal_, planned_goal) >= 1e-3)
+
+        if (!nav_core::NavGoal(planned_goal).equalPose(goal_manager_->currentGoal()))
         {
           ROS_INFO("Planned goal and latest received goal do not match. Assuming new goal issued; ignoring this "
-                   "plan.\n");
+                   "plan.");
+        }
+        else if (!goal_manager_->activeGoal())
+        {
+          ROS_INFO("Goal has become inactive; ignoring this plan.");
         }
         else
         {

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -56,6 +56,8 @@ namespace move_base {
     planner_plan_(NULL), latest_plan_(NULL), controller_plan_(NULL),
     runPlanner_(false), setup_(false), p_freq_change_(false), c_freq_change_(false), new_global_plan_(false) {
 
+    goal_manager_.reset(new nav_core::NavGoalMananger);
+
     as_ = new MoveBaseActionServer(ros::NodeHandle(), "move_base", boost::bind(&MoveBase::executeCb, this, _1), false);
 
     ros::NodeHandle private_nh("~");
@@ -157,6 +159,7 @@ namespace move_base {
 
       tc_ = blp_loader_.createInstance(local_planner);
       ROS_INFO("Created local_planner %s", local_planner.c_str());
+      tc_->setGoalManager(goal_manager_);
       tc_->initialize(blp_loader_.getName(local_planner), &tf_, controller_costmap_ros_);
     } catch (const pluginlib::PluginlibException& ex)
     {
@@ -268,7 +271,7 @@ namespace move_base {
 
         // wait for the current planner to finish planning
         boost::unique_lock<boost::mutex> lock(planner_mutex_);
-        
+
         // Clean up before initializing the new planner
         planner_plan_->clear();
         latest_plan_->clear();
@@ -316,6 +319,7 @@ namespace move_base {
         latest_plan_->clear();
         controller_plan_->clear();
         resetState();
+        tc_->setGoalManager(goal_manager_);
         tc_->initialize(blp_loader_.getName(config.base_local_planner), &tf_, controller_costmap_ros_);
       } catch (const pluginlib::PluginlibException& ex)
       {
@@ -444,6 +448,8 @@ namespace move_base {
     //first try to make a plan to the exact desired goal
     std::vector<geometry_msgs::PoseStamped> global_plan;
 
+    goal_manager_->setCurrentGoal(nav_core::NavGoal(req.goal));
+
     // NOTE: The implementation of makePlan is responsible for locking the costmap
     if(!planner_->makePlan(start, req.goal, global_plan) || global_plan.empty()){
       ROS_DEBUG_NAMED("move_base","Failed to find a plan to exact goal of (%.2f, %.2f), searching for a feasible goal within tolerance",
@@ -474,6 +480,8 @@ namespace move_base {
 
                 p.pose.position.y = req.goal.pose.position.y + y_offset * y_mult;
                 p.pose.position.x = req.goal.pose.position.x + x_offset * x_mult;
+
+                goal_manager_->setCurrentGoal(nav_core::NavGoal(p));
 
                 // NOTE: The implementation of makePlan is responsible for locking the costmap
                 if(planner_->makePlan(start, p, global_plan)){
@@ -509,9 +517,9 @@ namespace move_base {
 
   MoveBase::~MoveBase(){
     recovery_behaviors_.clear();
-    
+
     delete dsrv_;
-  
+
     as_feedback_timer_.stop();
     if(as_ != NULL)
       delete as_;
@@ -563,6 +571,7 @@ namespace move_base {
 
     geometry_msgs::PoseStamped start;
     tf::poseStampedTFToMsg(global_pose, start);
+    goal_manager_->setCurrentGoal(nav_core::NavGoal(goal));
 
     // NOTE: The implementation of makePlan is responsible for locking the costmap
     //if the planner fails or returns a zero length plan, planning failed
@@ -750,6 +759,7 @@ namespace move_base {
   {
     if(!isQuaternionValid(move_base_goal->target_pose.pose.orientation)){
       as_->setAborted(move_base_msgs::MoveBaseResult(), "Aborting on goal because it was sent with an invalid quaternion");
+      goal_manager_->setActiveGoal(false);  // setting no active goal
       return;
     }
 
@@ -794,10 +804,12 @@ namespace move_base {
 
           if(!isQuaternionValid(new_goal.target_pose.pose.orientation)){
             as_->setAborted(move_base_msgs::MoveBaseResult(), "Aborting on goal because it was sent with an invalid quaternion");
+            goal_manager_->setActiveGoal(false);  // setting no active goal
             return;
           }
 
           goal = goalToGlobalFrame(new_goal.target_pose);
+          goal_manager_->setCurrentGoal(nav_core::NavGoal(goal));
 
           //we'll make sure that we reset our state for the next execution cycle
           revertRecoveryChanges();
@@ -837,6 +849,7 @@ namespace move_base {
       //we also want to check if we've changed global frames because we need to transform our goal pose
       if(goal.header.frame_id != planner_costmap_ros_->getGlobalFrameID()){
         goal = goalToGlobalFrame(goal);
+        goal_manager_->setCurrentGoal(nav_core::NavGoal(goal));
 
         //we want to go back to the planning state for the next execution cycle
         revertRecoveryChanges();
@@ -1063,7 +1076,7 @@ namespace move_base {
 
       //we'll try to clear out space with any user-provided recovery behaviors
       case CLEARING:
-        ROS_DEBUG_NAMED("move_base","In clearing/recovery state");   
+        ROS_DEBUG_NAMED("move_base","In clearing/recovery state");
         if (planner_)
         {
           // This will invoke the resetPlanner method when recovery is called.
@@ -1195,6 +1208,7 @@ namespace move_base {
               return false;
             }
 
+            behavior->setGoalManager(goal_manager_);
             //initialize the recovery behavior with its name
             behavior->initialize(behavior_list[i]["name"], &tf_, planner_costmap_ros_, controller_costmap_ros_);
 
@@ -1239,18 +1253,21 @@ namespace move_base {
 
       //first, we'll load a recovery behavior to clear the costmap
       boost::shared_ptr<nav_core::RecoveryBehavior> cons_clear(recovery_loader_.createInstance("clear_costmap_recovery/ClearCostmapRecovery"));
+      cons_clear->setGoalManager(goal_manager_);
       cons_clear->initialize("conservative_reset", &tf_, planner_costmap_ros_, controller_costmap_ros_);
       recovery_behaviors_.push_back(cons_clear);
 
       //next, we'll load a recovery behavior to rotate in place
       boost::shared_ptr<nav_core::RecoveryBehavior> rotate(recovery_loader_.createInstance("rotate_recovery/RotateRecovery"));
       if(clearing_rotation_allowed_){
+        rotate->setGoalManager(goal_manager_);
         rotate->initialize("rotate_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
         recovery_behaviors_.push_back(rotate);
       }
 
       //next, we'll load a recovery behavior that will do an aggressive reset of the costmap
       boost::shared_ptr<nav_core::RecoveryBehavior> ags_clear(recovery_loader_.createInstance("clear_costmap_recovery/ClearCostmapRecovery"));
+      ags_clear->setGoalManager(goal_manager_);
       ags_clear->initialize("aggressive_reset", &tf_, planner_costmap_ros_, controller_costmap_ros_);
       recovery_behaviors_.push_back(ags_clear);
 
@@ -1266,6 +1283,8 @@ namespace move_base {
   }
 
   void MoveBase::resetState(){
+    goal_manager_->setActiveGoal(false);  // setting no active goal
+
     // Disable the planner thread
     boost::unique_lock<boost::mutex> lock(planner_mutex_);
     runPlanner_ = false;
@@ -1294,14 +1313,16 @@ namespace move_base {
     {
       // We do not have an instance of this planner in cache, so create one and cache it.
       ros::Time t = ros::Time::now();
-      global_planner_cache_.insert(std::make_pair(plugin_name, bgp_loader_.createInstance(plugin_name) ) ); 
+      global_planner_cache_.insert(std::make_pair(plugin_name, bgp_loader_.createInstance(plugin_name) ) );
+      global_planner_cache_[plugin_name]->setGoalManager(goal_manager_);
       global_planner_cache_[plugin_name]->initialize(bgp_loader_.getName(plugin_name), planner_costmap_ros_);
       ROS_DEBUG("Created new global planner plugin %s in %f seconds.", plugin_name.c_str(), (ros::Time::now() - t).toSec() );
     }
     else
     {
       ROS_DEBUG("Got cached global planner plugin: %s.", plugin_name.c_str() );
-    } 
+    }
+
     // Return the cached plugin instance.
     return global_planner_cache_[plugin_name];
   }

--- a/nav_core/CMakeLists.txt
+++ b/nav_core/CMakeLists.txt
@@ -3,10 +3,11 @@ project(nav_core)
 
 find_package(catkin REQUIRED
         COMPONENTS
-            std_msgs
-            geometry_msgs
-            tf
             costmap_2d
+            geometry_msgs
+            roscpp
+            std_msgs
+            tf
         )
 
 catkin_package(

--- a/nav_core/include/nav_core/base_global_planner.h
+++ b/nav_core/include/nav_core/base_global_planner.h
@@ -41,6 +41,7 @@
 #include <costmap_2d/costmap_2d_ros.h>
 #include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
+#include "nav_core/nav_goal_manager.h"
 
 namespace nav_core {
   /**
@@ -51,7 +52,7 @@ namespace nav_core {
     public:
       typedef boost::shared_ptr<BaseGlobalPlanner> Ptr;
       typedef boost::function <Ptr ()> FetchFunction;
-      
+
       /**
        * @brief Given a goal pose in the world, compute a plan. The implementation of this method is
        *        responsible for locking the costmap mutex.
@@ -60,7 +61,7 @@ namespace nav_core {
        * @param plan The plan... filled by the planner
        * @return True if a valid plan was found, false otherwise
        */
-      virtual bool makePlan(const geometry_msgs::PoseStamped& start, 
+      virtual bool makePlan(const geometry_msgs::PoseStamped& start,
           const geometry_msgs::PoseStamped& goal, std::vector<geometry_msgs::PoseStamped>& plan) = 0;
 
       /**
@@ -76,9 +77,23 @@ namespace nav_core {
       virtual void resetPlanner(){}
 
       /**
+       * Set the goal manager
+       * @param goal_manager goal manager
+       */
+      virtual void setGoalManager(NavGoalMananger::Ptr goal_manager)
+      {
+        goal_manager_ = goal_manager;
+      }
+
+      /**
        * @brief  Virtual destructor for the interface
        */
       virtual ~BaseGlobalPlanner(){}
+
+      /**
+       * @brief Common goal goal manager
+       */
+      NavGoalMananger::Ptr goal_manager_;
 
     protected:
       BaseGlobalPlanner(){}

--- a/nav_core/include/nav_core/base_local_planner.h
+++ b/nav_core/include/nav_core/base_local_planner.h
@@ -43,6 +43,7 @@
 #include <tf/transform_listener.h>
 #include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
+#include "nav_core/nav_goal_manager.h"
 
 namespace nav_core {
   /**
@@ -83,9 +84,23 @@ namespace nav_core {
       virtual void initialize(std::string name, tf::TransformListener* tf, costmap_2d::Costmap2DROS* costmap_ros) = 0;
 
       /**
+       * Set the goal manager
+       * @param goal_manager goal manager
+       */
+      virtual void setGoalManager(NavGoalMananger::Ptr goal_manager)
+      {
+        goal_manager_ = goal_manager;
+      }
+      
+      /**
        * @brief  Virtual destructor for the interface
        */
       virtual ~BaseLocalPlanner(){}
+
+      /**
+       * @brief Common goal goal manager
+       */
+      NavGoalMananger::Ptr goal_manager_;
 
     protected:
       BaseLocalPlanner(){}

--- a/nav_core/include/nav_core/nav_goal.h
+++ b/nav_core/include/nav_core/nav_goal.h
@@ -1,13 +1,39 @@
-/**
-Software License Agreement (proprietary)
-
-\file      nav_goal.h
-\authors   Jason Mercer <jmercer@clearpathrobotics.com>
-\copyright Copyright (c) 2016, Clearpath Robotics, Inc., All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, is not permitted without the
-express permission of Clearpath Robotics.
-*/
+/*********************************************************************
+*
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2016, Clearpath Robotics, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of Willow Garage, Inc. nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*
+* Author: Jason Mercer
+*********************************************************************/
 
 #ifndef NAV_NAV_CORE_NAV_GOAL_H_
 #define NAV_NAV_CORE_NAV_GOAL_H_

--- a/nav_core/include/nav_core/nav_goal.h
+++ b/nav_core/include/nav_core/nav_goal.h
@@ -81,7 +81,7 @@ public:
       return false;
     }
 
-    return angles::normalize_angle(tf::getYaw(p2.orientation) - tf::getYaw(p1.orientation)) <= angle_tol_rad;
+    return angles::shortest_angular_distance(tf::getYaw(p2.orientation), tf::getYaw(p1.orientation)) <= angle_tol_rad;
   }
 
   geometry_msgs::PoseStamped pose_;

--- a/nav_core/include/nav_core/nav_goal.h
+++ b/nav_core/include/nav_core/nav_goal.h
@@ -1,0 +1,74 @@
+/**
+Software License Agreement (proprietary)
+
+\file      nav_goal.h
+\authors   Jason Mercer <jmercer@clearpathrobotics.com>
+\copyright Copyright (c) 2016, Clearpath Robotics, Inc., All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, is not permitted without the
+express permission of Clearpath Robotics.
+*/
+
+#ifndef NAV_NAV_CORE_NAV_GOAL_H_
+#define NAV_NAV_CORE_NAV_GOAL_H_
+
+#include <geometry_msgs/PoseStamped.h>
+#include <tf/tf.h>
+#include <angles/angles.h>
+
+namespace nav_core
+{
+
+class NavGoal
+{
+public:
+  typedef size_t id_type;
+
+  NavGoal()
+    : id_(0)
+  {
+  }
+
+  NavGoal(geometry_msgs::PoseStamped p)
+    : id_(0)
+  {
+    pose_ = p;
+  }
+
+  bool equalPose(const NavGoal& g) const
+  {
+    return similarPose(g, 0, 0);
+  }
+
+  bool similarPose(const NavGoal& g, float dist_tol, float angle_tol_rad) const
+  {
+    const geometry_msgs::Pose& p1 = pose_.pose;
+    const geometry_msgs::Pose& p2 = g.pose_.pose;
+
+    const float xx = square(p1.position.x - p2.position.x);
+    const float yy = square(p1.position.y - p2.position.y);
+    const float zz = square(p1.position.z - p2.position.z);
+    const float rr = xx + yy + zz;
+
+    if (rr > square(dist_tol))
+    {
+      return false;
+    }
+
+    return angles::normalize_angle(tf::getYaw(p2.orientation) - tf::getYaw(p1.orientation)) <= angle_tol_rad;
+  }
+
+  geometry_msgs::PoseStamped pose_;
+  id_type id_;
+
+private:
+  inline float square(float x) const
+  {
+    return x*x;
+  }
+};
+
+
+}  // namespace nav_core
+
+#endif  // NAV_NAV_CORE_NAV_GOAL_H_

--- a/nav_core/include/nav_core/nav_goal_manager.h
+++ b/nav_core/include/nav_core/nav_goal_manager.h
@@ -1,13 +1,39 @@
-/**
-Software License Agreement (proprietary)
-
-\file      nav_goal_manager.h
-\authors   Jason Mercer <jmercer@clearpathrobotics.com>
-\copyright Copyright (c) 2016, Clearpath Robotics, Inc., All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, is not permitted without the
-express permission of Clearpath Robotics.
-*/
+/*********************************************************************
+*
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2016, Clearpath Robotics, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of Willow Garage, Inc. nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*
+* Author: Jason Mercer
+*********************************************************************/
 
 #ifndef NAV_NAV_CORE_NAV_GOAL_MANAGER_H_
 #define NAV_NAV_CORE_NAV_GOAL_MANAGER_H_

--- a/nav_core/include/nav_core/nav_goal_manager.h
+++ b/nav_core/include/nav_core/nav_goal_manager.h
@@ -1,0 +1,88 @@
+/**
+Software License Agreement (proprietary)
+
+\file      nav_goal_manager.h
+\authors   Jason Mercer <jmercer@clearpathrobotics.com>
+\copyright Copyright (c) 2016, Clearpath Robotics, Inc., All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, is not permitted without the
+express permission of Clearpath Robotics.
+*/
+
+#ifndef NAV_NAV_CORE_NAV_GOAL_MANAGER_H_
+#define NAV_NAV_CORE_NAV_GOAL_MANAGER_H_
+
+#include <boost/shared_ptr.hpp>
+#include <boost/thread.hpp>
+#include "nav_core/nav_goal.h"
+
+namespace nav_core
+{
+
+class NavGoalMananger
+{
+public:
+  typedef boost::shared_ptr<NavGoalMananger> Ptr;
+  NavGoalMananger()
+    : active_goal_(false), next_goal_id_(0)
+  {
+
+  }
+
+  /**
+   * @brief setCurrentGoal set the goal for the goal manager
+   * @param goal new goal
+   */
+  void setCurrentGoal(const NavGoal& goal)
+  {
+    boost::upgrade_lock<boost::shared_mutex> lock(_access);
+    boost::upgrade_to_unique_lock<boost::shared_mutex> write_lock(lock);
+
+    if (!active_goal_ || !goal.equalPose(current_goal_))
+    {
+      current_goal_ = goal;
+      current_goal_.id_ = ++next_goal_id_;
+    }
+
+    setActiveGoal(true);
+  }
+  /**
+   * @brief currentGoal get the current goal of the manager
+   * @return current goal
+   */
+  NavGoal currentGoal()
+  {
+    boost::shared_lock<boost::shared_mutex> read_lock(_access);
+
+    return NavGoal(current_goal_);
+  }
+
+  /**
+   * @brief setActiveGoal set if there is or is not an active goal
+   * @param b new active goal flag
+   */
+  void setActiveGoal(bool b)
+  {
+    active_goal_ = b;
+  }
+
+  /**
+   * @brief activeGoal determine if there is an active goal
+   * @return active goal flag
+   */
+  bool activeGoal() const
+  {
+    return active_goal_;
+  }
+
+
+private:
+  NavGoal current_goal_;
+  bool active_goal_;
+  boost::shared_mutex _access;
+  NavGoal::id_type next_goal_id_;
+};
+
+}  // namespace move_base
+
+#endif  // NAV_NAV_CORE_NAV_GOAL_MANAGER_H_

--- a/nav_core/include/nav_core/recovery_behavior.h
+++ b/nav_core/include/nav_core/recovery_behavior.h
@@ -40,6 +40,7 @@
 #include <tf/transform_listener.h>
 #include <nav_core/base_global_planner.h>
 #include <nav_core/base_local_planner.h>
+#include "nav_core/nav_goal_manager.h"
 
 namespace nav_core {
   /**
@@ -51,8 +52,8 @@ namespace nav_core {
       /**
        * @brief  Initialization function for the RecoveryBehavior
        * @param tf A pointer to a transform listener
-       * @param global_costmap A pointer to the global_costmap used by the navigation stack 
-       * @param local_costmap A pointer to the local_costmap used by the navigation stack 
+       * @param global_costmap A pointer to the global_costmap used by the navigation stack
+       * @param local_costmap A pointer to the local_costmap used by the navigation stack
        */
       virtual void initialize(std::string name, tf::TransformListener* tf, costmap_2d::Costmap2DROS* global_costmap, costmap_2d::Costmap2DROS* local_costmap) = 0;
 
@@ -92,6 +93,20 @@ namespace nav_core {
       {
         global_planner_fetch_ = f;
       }
+
+      /**
+       * Set the goal manager
+       * @param goal_manager goal manager
+       */
+      virtual void setGoalManager(NavGoalMananger::Ptr goal_manager)
+      {
+        goal_manager_ = goal_manager;
+      }
+
+      /**
+       * @brief Common goal goal manager
+       */
+      NavGoalMananger::Ptr goal_manager_;
 
     protected:
       RecoveryBehavior(){}


### PR DESCRIPTION
Adding a mechanism to share the validity/activeness of the current goal so that planners and recovery strategies can stop running. 

