### PR TITLE
Custom preempt callback in move_base

### DIFF
--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -224,6 +224,12 @@ namespace move_base {
        */
       void asFeedbackTimerCallback(const ros::TimerEvent&);
 
+      /**
+       * @brief Custom preemption callback to be called when the action server detects preemption
+       */
+      void asPreemptCallback();
+
+
       tf::TransformListener& tf_;
 
       MoveBaseActionServer* as_;


### PR DESCRIPTION
Registering custom callback with simple action server so we can preempt even during moving recoveries. 

@skaynama @p6chen 