### PR TITLE
CORE-3682-null-ptr-check

### DIFF
--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -782,7 +782,7 @@ namespace move_base {
     // For robustness, we need to check for that null ptr here and set the state to
     // aborted rather than crashing.
     // CORE-3682
-    if (!move_base_goal.get())
+    if (move_base_goal.get() == NULL)
     {
       as_->setAborted(move_base_msgs::MoveBaseResult(), "Aborting on goal because it was a NULL pointer");
       goal_manager_->setActiveGoal(false);  // setting no active goal


### PR DESCRIPTION
Checking for null ptrs from the action server.

Changed preempt to set current goals as inactive, allowing new goals to filter in later.