### PR TITLE
CORE-3611: Add >= check in addition to setting planner_patience to 0.…

### DIFF
--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -744,7 +744,7 @@ namespace move_base {
 
         //check if we've tried to make a plan for over our time limit
         lock.lock();
-        if(ros::Time::now() > attempt_end && runPlanner_){
+        if(ros::Time::now() >= attempt_end && runPlanner_){
           //we'll move into our obstacle clearing mode
           /* We're about to change the state to CLEARING (recovery).
            * Since performing the recovery process is slower than this


### PR DESCRIPTION
… This ensures that after a loop of death is detected, we invoke recovery.

@skaynama, @jasonimercer , @p6chen 