### PR TITLE
Add the ability to do custom footprint checks

### DIFF
--- a/base_local_planner/include/base_local_planner/costmap_model.h
+++ b/base_local_planner/include/base_local_planner/costmap_model.h
@@ -48,7 +48,7 @@ namespace base_local_planner
 {
 
 /**
- * @brief List of checks that are understood by the CostmapModel. FootprintLoopDiamondX is the default
+ * @brief List of checks that are understood by the CostmapModel. FootprintLoop is the default
  *        if none are explicitly supplied to the CostmapModel constructor.
  */
 enum FootprintCheckMethod
@@ -72,7 +72,7 @@ public:
    * @param costmap The costmap that should be used
    * @return
    */
-  CostmapModel(const costmap_2d::Costmap2D& costmap, FootprintCheckMethod = FootprintLoopDiamondX);
+  CostmapModel(const costmap_2d::Costmap2D& costmap, FootprintCheckMethod = FootprintLoop);
 
   /**
    * @brief  Destructor for the world model
@@ -92,6 +92,37 @@ public:
   virtual double footprintCost(const geometry_msgs::Point& position,
                                const std::vector<geometry_msgs::Point>& footprint,
                                double inscribed_radius, double circumscribed_radius);
+
+  /**
+   * @brief  Checks if any obstacles in the costmap lie inside a convex footprint that is rasterized into the grid
+   *         using a specified method
+   * @param  position The position of the robot in world coordinates
+   * @param  footprint The specification of the footprint of the robot in world coordinates
+   * @param  inscribed_radius The radius of the inscribed circle of the robot
+   * @param  circumscribed_radius The radius of the circumscribed circle of the robot
+   * @param  method Method to use for the foorprint check
+   * @return Positive if all the points lie outside the footprint, negative otherwise
+   */
+  virtual double footprintCost(const geometry_msgs::Point& position,
+                               const std::vector<geometry_msgs::Point>& footprint,
+                               double inscribed_radius, double circumscribed_radius,
+                               FootprintCheckMethod method);
+
+  /**
+   * @brief  Checks if any obstacles in the costmap lie inside a convex footprint that is rasterized into the grid
+   *         using a specified method
+   * @param  x X coordinates of base pose
+   * @param  y Y coordinates of base pose
+   * @param  theta yaw of the base pose
+   * @param  footprint_spec The specification of the footprint of the robot in world coordinates
+   * @param  method Method to use for the foorprint check
+   * @param  inscribed_radius The radius of the inscribed circle of the robot (Default: 0)
+   * @param  circumscribed_radius The radius of the circumscribed circle of the robot (Default: 0)
+   * @return
+   */
+  double footprintCost(double x, double y, double theta,
+                       const std::vector<geometry_msgs::Point>& footprint_spec,
+                       FootprintCheckMethod method, double inscribed_radius = 0.0, double circumscribed_radius=0.0);
 
   /**
    * @brief  Checks if any obstacles in the costmap lie inside a convex footprint that is rasterized into the grid

--- a/base_local_planner/include/base_local_planner/costmap_model.h
+++ b/base_local_planner/include/base_local_planner/costmap_model.h
@@ -194,6 +194,8 @@ public:
                             const std::vector<geometry_msgs::Point>& footprint,
                             double inscribed_radius, double circumscribed_radius);
 
+  FootprintCheckMethod check_method_;  ///< @brief Which method to use for checks
+
 protected:
   /**
    * @brief Raytrace the polygon perimeter and collect the cells in polygon_cells
@@ -287,8 +289,6 @@ protected:
   double realPointCost(double x, double y);
 
   const costmap_2d::Costmap2D& costmap_;  ///< @brief Allows access of costmap obstacle information
-
-  FootprintCheckMethod check_method_;  ///< @brief Which method to use for checks
 };
 
 }  // namespace base_local_planner

--- a/base_local_planner/include/base_local_planner/costmap_model.h
+++ b/base_local_planner/include/base_local_planner/costmap_model.h
@@ -2,7 +2,7 @@
 *
 * Software License Agreement (BSD License)
 *
-*  Copyright (c) 2008, Willow Garage, Inc.
+*  Copyright (c) 2016, Clearpath Robotics, Inc.
 *  All rights reserved.
 *
 *  Redistribution and use in source and binary forms, with or without
@@ -15,7 +15,7 @@
 *     copyright notice, this list of conditions and the following
 *     disclaimer in the documentation and/or other materials provided
 *     with the distribution.
-*   * Neither the name of the Willow Garage nor the names of its
+*   * Neither the name of Clearpath Robotics, Inc. nor the names of its
 *     contributors may be used to endorse or promote products derived
 *     from this software without specific prior written permission.
 *
@@ -32,68 +32,264 @@
 *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 *  POSSIBILITY OF SUCH DAMAGE.
 *
-* Author: Eitan Marder-Eppstein
+* Author: Jason Mercer
 *********************************************************************/
-#ifndef TRAJECTORY_ROLLOUT_COSTMAP_MODEL_
-#define TRAJECTORY_ROLLOUT_COSTMAP_MODEL_
+
+#ifndef BASE_LOCAL_PLANNER_COSTMAP_MODEL
+#define BASE_LOCAL_PLANNER_COSTMAP_MODEL
 
 #include <base_local_planner/world_model.h>
 // For obstacle data access
 #include <costmap_2d/costmap_2d.h>
+#include <costmap_2d/cost_values.h>
+#include <vector>
 
-namespace base_local_planner {
-  /**
-   * @class CostmapModel
-   * @brief A class that implements the WorldModel interface to provide grid
-   * based collision checks for the trajectory controller using the costmap.
-   */
-  class CostmapModel : public WorldModel {
-    public:
-      /**
-       * @brief  Constructor for the CostmapModel
-       * @param costmap The costmap that should be used
-       * @return 
-       */
-      CostmapModel(const costmap_2d::Costmap2D& costmap);
+namespace base_local_planner
+{
 
-      /**
-       * @brief  Destructor for the world model
-       */
-      virtual ~CostmapModel(){}
-      using WorldModel::footprintCost;
-
-      /**
-       * @brief  Checks if any obstacles in the costmap lie inside a convex footprint that is rasterized into the grid
-       * @param  position The position of the robot in world coordinates
-       * @param  footprint The specification of the footprint of the robot in world coordinates
-       * @param  inscribed_radius The radius of the inscribed circle of the robot
-       * @param  circumscribed_radius The radius of the circumscribed circle of the robot
-       * @return Positive if all the points lie outside the footprint, negative otherwise
-       */
-      virtual double footprintCost(const geometry_msgs::Point& position, const std::vector<geometry_msgs::Point>& footprint,
-          double inscribed_radius, double circumscribed_radius);
-
-    private:
-      /**
-       * @brief  Rasterizes a line in the costmap grid and checks for collisions
-       * @param x0 The x position of the first cell in grid coordinates
-       * @param y0 The y position of the first cell in grid coordinates
-       * @param x1 The x position of the second cell in grid coordinates
-       * @param y1 The y position of the second cell in grid coordinates
-       * @return A positive cost for a legal line... negative otherwise
-       */
-      double lineCost(int x0, int x1, int y0, int y1);
-
-      /**
-       * @brief  Checks the cost of a point in the costmap
-       * @param x The x position of the point in cell coordinates 
-       * @param y The y position of the point in cell coordinates 
-       * @return A positive cost for a legal point... negative otherwise
-       */
-      double pointCost(int x, int y);
-
-      const costmap_2d::Costmap2D& costmap_; ///< @brief Allows access of costmap obstacle information
-
-  };
+/**
+ * @brief List of checks that are understood by the CostmapModel. FootprintLoopDiamondX is the default
+ *        if none are explicitly supplied to the CostmapModel constructor.
+ */
+enum FootprintCheckMethod
+{
+  FootprintLoop,
+  FootprintLoopDiamond,
+  FootprintLoopDiamondX,
+  EveryPixel
 };
-#endif
+
+/**
+ * @class CostmapModel
+ * @brief A class that implements the WorldModel interface to provide grid
+ * based collision checks for the trajectory controller using the costmap.
+ */
+class CostmapModel : public WorldModel
+{
+public:
+  /**
+   * @brief  Constructor for the CostmapModel
+   * @param costmap The costmap that should be used
+   * @return
+   */
+  CostmapModel(const costmap_2d::Costmap2D& costmap, FootprintCheckMethod = FootprintLoopDiamondX);
+
+  /**
+   * @brief  Destructor for the world model
+   */
+  virtual ~CostmapModel() {}
+  using WorldModel::footprintCost;
+
+  /**
+   * @brief  Checks if any obstacles in the costmap lie inside a convex footprint that is rasterized into the grid
+   *         using the method defined in the object constructor (FootprintLoop by default)
+   * @param  position The position of the robot in world coordinates
+   * @param  footprint The specification of the footprint of the robot in world coordinates
+   * @param  inscribed_radius The radius of the inscribed circle of the robot
+   * @param  circumscribed_radius The radius of the circumscribed circle of the robot
+   * @return Positive if all the points lie outside the footprint, negative otherwise
+   */
+  virtual double footprintCost(const geometry_msgs::Point& position,
+                               const std::vector<geometry_msgs::Point>& footprint,
+                               double inscribed_radius, double circumscribed_radius);
+
+  /**
+   * @brief  Checks if any obstacles in the costmap lie inside a convex footprint that is rasterized into the grid
+   *         by looking along the edges of the given footprint at a position for a lethal obstacle.
+   * @param  position The position of the robot in world coordinates
+   * @param  footprint The specification of the footprint of the robot in world coordinates
+   * @param  inscribed_radius The radius of the inscribed circle of the robot
+   * @param  circumscribed_radius The radius of the circumscribed circle of the robot
+   * @return Positive if all the points lie outside the footprint, negative otherwise
+   */
+  virtual double footprintCostLoop(const geometry_msgs::Point& position,
+                                   const std::vector<geometry_msgs::Point>& footprint,
+                                   double inscribed_radius, double circumscribed_radius);
+
+  /**
+   * @brief  Checks if any obstacles in the costmap lie inside a convex footprint that is rasterized into the grid
+   *         by checking every pixel in the footprint at a position for a lethal obstacle
+   * @param  position The position of the robot in world coordinates
+   * @param  footprint The specification of the footprint of the robot in world coordinates
+   * @param  inscribed_radius The radius of the inscribed circle of the robot
+   * @param  circumscribed_radius The radius of the circumscribed circle of the robot
+   * @return Positive if all the points lie outside the footprint, negative otherwise
+   */
+  virtual double footprintCostEveryPixel(const geometry_msgs::Point& position,
+                                         const std::vector<geometry_msgs::Point>& footprint,
+                                         double inscribed_radius, double circumscribed_radius);
+
+  /**
+   * @brief  Checks if any obstacles in the costmap lie inside a convex footprint that is rasterized into the grid
+   *         by checking the footprint perimeter and the centers of adjacent edges joined together
+   * @param  position The position of the robot in world coordinates
+   * @param  footprint The specification of the footprint of the robot in world coordinates
+   * @param  inscribed_radius The radius of the inscribed circle of the robot
+   * @param  circumscribed_radius The radius of the circumscribed circle of the robot
+   * @return Positive if all the points lie outside the footprint, negative otherwise
+   */
+  virtual double footprintCostDiamond(const geometry_msgs::Point& position,
+                                      const std::vector<geometry_msgs::Point>& footprint,
+                                      double inscribed_radius, double circumscribed_radius);
+
+  /**
+   * @brief  Checks if any obstacles in the costmap lie inside a convex footprint that is rasterized into the grid
+   *         by checking the footprint perimeter, the centers of adjacent edges joined together and next nearest
+   *         vertices joined together
+   * @param  position The position of the robot in world coordinates
+   * @param  footprint The specification of the footprint of the robot in world coordinates
+   * @param  inscribed_radius The radius of the inscribed circle of the robot
+   * @param  circumscribed_radius The radius of the circumscribed circle of the robot
+   * @return Positive if all the points lie outside the footprint, negative otherwise
+   */
+  virtual double footprintCostDiamondX(const geometry_msgs::Point& position,
+                                       const std::vector<geometry_msgs::Point>& footprint,
+                                       double inscribed_radius, double circumscribed_radius);
+
+  /**
+   * @brief  Checks if any obstacles lie along the lines connecting the midpoints of adjacent edges
+   * @param  position The position of the robot in world coordinates
+   * @param  footprint The specification of the footprint of the robot in world coordinates
+   * @param  inscribed_radius The radius of the inscribed circle of the robot
+   * @param  circumscribed_radius The radius of the circumscribed circle of the robot
+   * @return Positive if all the points lie outside the footprint, negative otherwise
+   */
+  virtual double diamondCost(const geometry_msgs::Point& position,
+                             const std::vector<geometry_msgs::Point>& footprint,
+                             double inscribed_radius, double circumscribed_radius);
+
+  /**
+   * @brief  Check if an obstacle lies along the perimeter of the footprint
+   * @param  position The position of the robot in world coordinates
+   * @param  footprint The specification of the footprint of the robot in world coordinates
+   * @param  inscribed_radius The radius of the inscribed circle of the robot
+   * @param  circumscribed_radius The radius of the circumscribed circle of the robot
+   * @return Positive if an obstacle is not found on the perimeter, negative otherwise
+   */
+  virtual double loopCost(const geometry_msgs::Point& position,
+                          const std::vector<geometry_msgs::Point>& footprint,
+                          double inscribed_radius, double circumscribed_radius);
+
+  /**
+   * @brief  Checks if any obstacles lie along the lines next nearest vertices on the footprint loop
+   * @param  position The position of the robot in world coordinates
+   * @param  footprint The specification of the footprint of the robot in world coordinates
+   * @param  inscribed_radius The radius of the inscribed circle of the robot
+   * @param  circumscribed_radius The radius of the circumscribed circle of the robot
+   * @return Positive if all the points lie outside the footprint, negative otherwise
+   */
+  virtual double xCost(const geometry_msgs::Point& position,
+                       const std::vector<geometry_msgs::Point>& footprint,
+                       double inscribed_radius, double circumscribed_radius);
+
+  /**
+   * @brief  Check if the center cost is above the inscribed cost
+   * @param  position The position of the robot in world coordinates
+   * @param  footprint The specification of the footprint of the robot in world coordinates
+   * @param  inscribed_radius The radius of the inscribed circle of the robot
+   * @param  circumscribed_radius The radius of the circumscribed circle of the robot
+   * @return Positive if the position cost is less than inscribed cost, negative otherwise
+   */
+  virtual double centerCost(const geometry_msgs::Point& position,
+                            const std::vector<geometry_msgs::Point>& footprint,
+                            double inscribed_radius, double circumscribed_radius);
+
+protected:
+  /**
+   * @brief Raytrace the polygon perimeter and collect the cells in polygon_cells
+   * @param polygon polygon to trace
+   * @param polygon_cells set of cells making up the perimeter
+   */
+  void polygonOutlineCells(const std::vector<costmap_2d::MapLocation>& polygon,
+                           std::vector<costmap_2d::MapLocation>& polygon_cells) const;
+
+  /**
+   * @brief Collect the points inside a polygon
+   * @param polygon polygon containing cells
+   * @param polygon_cells cells in polygon
+   */
+  void convexFillCells(const std::vector<costmap_2d::MapLocation>& polygon,
+                       std::vector<costmap_2d::MapLocation>& polygon_cells) const;
+
+  /**
+   * @brief Rasterizes a line in the costmap grid and collect coordinates
+   * @param x0 The x position of the first cell in grid coordinates
+   * @param y0 The y position of the first cell in grid coordinates
+   * @param x1 The x position of the second cell in grid coordinates
+   * @param y1 The y position of the second cell in grid coordinates
+   * @param polygon_cells set of cells making up the line
+   * @param max_length maximum number of cells to count (default UINT_MAX)
+   */
+  void raytraceCells(unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
+                     std::vector<costmap_2d::MapLocation>& polygon_cells,
+                     unsigned int max_length = UINT_MAX) const;
+
+  /**
+   * @brief A 2D implementation of Bresenham's raytracing algorithm. Collects cells.
+   */
+  void bresenham2D(unsigned int abs_da, unsigned int abs_db, int error_b,
+                   int offset_a, int offset_b, unsigned int offset,
+                   unsigned int max_length,
+                   std::vector<costmap_2d::MapLocation>& polygon_cells) const;
+
+  /**
+   * @brief maxCellValue find the maximum cell value in a polygon. Lethal is considered max and will
+   *        trigger an early return
+   * @param polygon polygon to consider
+   * @return maximum cell value inside the polygon
+   */
+  unsigned char maxCellValue(const std::vector<costmap_2d::MapLocation>& polygon) const;
+
+  /**
+   * @brief get sign of input (except zero which is negative in this case)
+   * @param x input
+   * @return 1 if input is greater than 0, else -1
+   */
+  inline int sign(int x) const
+  {
+    return x > 0 ? 1 : -1;
+  }
+
+  /**
+   * @brief  Rasterizes a line in the costmap grid and checks for collisions
+   * @param x0 The x position of the first cell in grid coordinates
+   * @param y0 The y position of the first cell in grid coordinates
+   * @param x1 The x position of the second cell in grid coordinates
+   * @param y1 The y position of the second cell in grid coordinates
+   * @return A positive cost for a legal line... negative otherwise
+   */
+  double lineCost(int x0, int x1, int y0, int y1);
+
+  /**
+   * @brief  Rasterizes a line in the costmap grid and checks for collisions after conversion to map coordinates
+   * @param x0 The x position of the first cell in grid coordinates
+   * @param y0 The y position of the first cell in grid coordinates
+   * @param x1 The x position of the second cell in grid coordinates
+   * @param y1 The y position of the second cell in grid coordinates
+   * @return A positive cost for a legal line... negative otherwise
+   */
+  double realLineCost(double x0, double x1, double y0, double y1);
+
+  /**
+   * @brief  Checks the cost of a point in the costmap
+   * @param x The x position of the point in cell coordinates
+   * @param y The y position of the point in cell coordinates
+   * @return A positive cost for a legal point... negative otherwise
+   */
+  double pointCost(int x, int y);
+
+  /**
+   * @brief Checks the cost of a point in the costmap after converting from global coordinates
+   * @param x The x position of the point in cell coordinates
+   * @param y The y position of the point in cell coordinates
+   * @return A positive cost for a legal point... negative otherwise
+   */
+  double realPointCost(double x, double y);
+
+  const costmap_2d::Costmap2D& costmap_;  ///< @brief Allows access of costmap obstacle information
+
+  FootprintCheckMethod check_method_;  ///< @brief Which method to use for checks
+};
+
+}  // namespace base_local_planner
+#endif  // BASE_LOCAL_PLANNER_COSTMAP_MODEL

--- a/base_local_planner/src/costmap_model.cpp
+++ b/base_local_planner/src/costmap_model.cpp
@@ -2,7 +2,7 @@
 *
 * Software License Agreement (BSD License)
 *
-*  Copyright (c) 2008, Willow Garage, Inc.
+*  Copyright (c) 2016, Clearpath Robotics, Inc.
 *  All rights reserved.
 *
 *  Redistribution and use in source and binary forms, with or without
@@ -15,7 +15,7 @@
 *     copyright notice, this list of conditions and the following
 *     disclaimer in the documentation and/or other materials provided
 *     with the distribution.
-*   * Neither the name of the Willow Garage nor the names of its
+*   * Neither the name of Clearpath Robotics, Inc. nor the names of its
 *     contributors may be used to endorse or promote products derived
 *     from this software without specific prior written permission.
 *
@@ -32,113 +32,535 @@
 *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 *  POSSIBILITY OF SUCH DAMAGE.
 *
-* Author: Eitan Marder-Eppstein
+* Author: Jason Mercer
 *********************************************************************/
+
 #include <base_local_planner/line_iterator.h>
 #include <base_local_planner/costmap_model.h>
 #include <costmap_2d/cost_values.h>
+#include <vector>
+#include <algorithm>
 
-using namespace std;
-using namespace costmap_2d;
+namespace base_local_planner
+{
 
-namespace base_local_planner {
-  CostmapModel::CostmapModel(const Costmap2D& ma) : costmap_(ma) {}
+CostmapModel::CostmapModel(const costmap_2d::Costmap2D& ma, base_local_planner::FootprintCheckMethod method)
+  : costmap_(ma), check_method_(method)
+{
+}
 
-  double CostmapModel::footprintCost(const geometry_msgs::Point& position, const std::vector<geometry_msgs::Point>& footprint, 
-      double inscribed_radius, double circumscribed_radius){
+// The main method that uses the supplied check_method in the object constructor
+double CostmapModel::footprintCost(const geometry_msgs::Point& position,
+                                   const std::vector<geometry_msgs::Point>& footprint,
+                                   double inscribed_radius,
+                                   double circumscribed_radius)
+{
+  switch (check_method_)
+  {
+  case FootprintLoop:
+  {
+    return footprintCostLoop(position, footprint, inscribed_radius, circumscribed_radius);
+  }
 
-    //used to put things into grid coordinates
-    unsigned int cell_x, cell_y;
+  case FootprintLoopDiamond:
+  {
+    return footprintCostDiamond(position, footprint, inscribed_radius, circumscribed_radius);
+  }
 
-    //get the cell coord of the center point of the robot
-    if(!costmap_.worldToMap(position.x, position.y, cell_x, cell_y))
-      return -1.0;
+  case FootprintLoopDiamondX:
+  {
+    return footprintCostDiamondX(position, footprint, inscribed_radius, circumscribed_radius);
+  }
 
-    //if the center point is LETHAL or INSCRIBED the footprint must be colliding
-    unsigned char cost = costmap_.getCost(cell_x, cell_y);
-    if(cost == LETHAL_OBSTACLE || cost == INSCRIBED_INFLATED_OBSTACLE)
+  case EveryPixel:
+  {
+    return footprintCostEveryPixel(position, footprint, inscribed_radius, circumscribed_radius);
+  }
+  }
+
+  // If we don't understand the method then we will return an obstacle
+  return -1.0;
+}
+
+void CostmapModel::polygonOutlineCells(const std::vector<costmap_2d::MapLocation>& polygon,
+                                       std::vector<costmap_2d::MapLocation>& polygon_cells) const
+{
+  for (unsigned int i = 0; i < polygon.size() - 1; ++i)
+  {
+    raytraceCells(polygon[i].x, polygon[i].y, polygon[i + 1].x, polygon[i + 1].y, polygon_cells);
+  }
+
+  if (!polygon.empty())
+  {
+    unsigned int last_index = polygon.size() - 1;
+    // we also need to close the polygon by going from the last point to the first
+    raytraceCells(polygon[last_index].x, polygon[last_index].y, polygon[0].x, polygon[0].y, polygon_cells);
+  }
+}
+
+// TODO(jmercer): The following is copied from costmap_2d for robustness
+// but it iterates through the cells column by column which is against the
+// direction of memory. The following code should be changed to iterate along
+// the X direction.
+void CostmapModel::convexFillCells(const std::vector<costmap_2d::MapLocation>& polygon,
+                                   std::vector<costmap_2d::MapLocation>& polygon_cells) const
+{
+  // The following is copied from costmap_2d with style changes and explicit adds to polygon_cells
+  // rather than using a custom action.
+
+  // we need a minimum polygon of a triangle
+  if (polygon.size() < 3)
+  {
+    return;
+  }
+
+  // first get the cells that make up the outline of the polygon
+  polygonOutlineCells(polygon, polygon_cells);
+
+  // quick bubble sort to sort points by x
+  costmap_2d::MapLocation swap;
+  unsigned int i = 0;
+  while (i < polygon_cells.size() - 1)
+  {
+    if (polygon_cells[i].x > polygon_cells[i + 1].x)
+    {
+      swap = polygon_cells[i];
+      polygon_cells[i] = polygon_cells[i + 1];
+      polygon_cells[i + 1] = swap;
+
+      if (i > 0)
+      {
+        --i;
+      }
+    }
+    else
+    {
+      ++i;
+    }
+  }
+
+  i = 0;
+  costmap_2d::MapLocation min_pt;
+  costmap_2d::MapLocation max_pt;
+  unsigned int min_x = polygon_cells[0].x;
+  unsigned int max_x = polygon_cells[polygon_cells.size() - 1].x;
+
+  // walk through each column and mark cells inside the polygon
+  for (unsigned int x = min_x; x <= max_x; ++x)
+  {
+    if (i >= polygon_cells.size() - 1)
+    {
+      break;
+    }
+
+    if (polygon_cells[i].y < polygon_cells[i + 1].y)
+    {
+      min_pt = polygon_cells[i];
+      max_pt = polygon_cells[i + 1];
+    }
+    else
+    {
+      min_pt = polygon_cells[i + 1];
+      max_pt = polygon_cells[i];
+    }
+
+    i += 2;
+    while (i < polygon_cells.size() && polygon_cells[i].x == x)
+    {
+      if (polygon_cells[i].y < min_pt.y)
+      {
+        min_pt = polygon_cells[i];
+      }
+      else if (polygon_cells[i].y > max_pt.y)
+      {
+        max_pt = polygon_cells[i];
+      }
+      ++i;
+    }
+
+    costmap_2d::MapLocation pt;
+    // loop though cells in the column
+    for (unsigned int y = min_pt.y; y < max_pt.y; ++y)
+    {
+      pt.x = x;
+      pt.y = y;
+      polygon_cells.push_back(pt);
+    }
+  }
+}
+
+void CostmapModel::raytraceCells(unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1,
+                                 std::vector<costmap_2d::MapLocation>& polygon_cells, unsigned int max_length) const
+{
+  int dx = x1 - x0;
+  int dy = y1 - y0;
+
+  unsigned int abs_dx = abs(dx);
+  unsigned int abs_dy = abs(dy);
+
+  int offset_dx = sign(dx);
+  int offset_dy = sign(dy) * costmap_.getSizeInCellsX();
+
+  unsigned int offset = y0 * costmap_.getSizeInCellsX() + x0;
+
+  // we need to chose how much to scale our dominant dimension, based on the maximum length of the line
+  double dist = hypot(dx, dy);
+  double scale = (dist == 0.0) ? 1.0 : std::min(1.0, max_length / dist);
+
+  // if x is dominant
+  if (abs_dx >= abs_dy)
+  {
+    int error_y = abs_dx / 2;
+    bresenham2D(abs_dx, abs_dy, error_y, offset_dx, offset_dy, offset, (unsigned int)(scale * abs_dx), polygon_cells);
+    return;
+  }
+
+  // otherwise y is dominant
+  int error_x = abs_dy / 2;
+  bresenham2D(abs_dy, abs_dx, error_x, offset_dy, offset_dx, offset, (unsigned int)(scale * abs_dy), polygon_cells);
+}
+
+unsigned char CostmapModel::maxCellValue(const std::vector<costmap_2d::MapLocation>& polygon_cells) const
+{
+  unsigned char max_cell = costmap_2d::FREE_SPACE;
+
+  for (size_t k = 0; k < polygon_cells.size(); k++)
+  {
+    const costmap_2d::MapLocation& m = polygon_cells[k];
+    const unsigned char val_k = costmap_.getCost(m.x, m.y);
+
+    if (val_k == costmap_2d::LETHAL_OBSTACLE)
+    {
+      return costmap_2d::LETHAL_OBSTACLE;
+    }
+
+    if (val_k < costmap_2d::LETHAL_OBSTACLE)
+    {
+      max_cell = std::max<unsigned char>(max_cell, val_k);
+    }
+  }
+
+  return max_cell;
+}
+
+void CostmapModel::bresenham2D(unsigned int abs_da, unsigned int abs_db, int error_b,
+                               int offset_a, int offset_b, unsigned int offset, unsigned int max_length,
+                               std::vector<costmap_2d::MapLocation>& polygon_cells) const
+{
+  costmap_2d::MapLocation m;
+
+  unsigned int end = std::min(max_length, abs_da);
+  for (unsigned int i = 0; i < end; ++i)
+  {
+    costmap_.indexToCells(offset, m.x, m.y);
+    polygon_cells.push_back(m);
+
+    offset += offset_a;
+    error_b += abs_db;
+    if ((unsigned int)error_b >= abs_da)
+    {
+      offset += offset_b;
+      error_b -= abs_da;
+    }
+  }
+
+  costmap_.indexToCells(offset, m.x, m.y);
+  polygon_cells.push_back(m);
+}
+
+double CostmapModel::footprintCostLoop(const geometry_msgs::Point& position,
+                                       const std::vector<geometry_msgs::Point>& footprint,
+                                       double inscribed_radius, double circumscribed_radius)
+{
+  // check for inscribed at center
+  const double cost = centerCost(position, footprint, inscribed_radius, circumscribed_radius);
+  if (cost < 0)
+  {
+    return -1.0;
+  }
+
+  const double loop_cost = loopCost(position, footprint, inscribed_radius, circumscribed_radius);
+  if (loop_cost < 0)
+  {
+    return -1.0;
+  }
+
+  return std::max<double>(cost, loop_cost);
+}
+
+double CostmapModel::footprintCostDiamond(const geometry_msgs::Point& position,
+                                          const std::vector<geometry_msgs::Point>& footprint,
+                                          double inscribed_radius, double circumscribed_radius)
+{
+  const double loop_cost = footprintCostLoop(position, footprint, inscribed_radius, circumscribed_radius);
+
+  if (loop_cost < 0)
+  {
+    return -1.0;
+  }
+
+  const double diamond_cost = diamondCost(position, footprint, inscribed_radius, circumscribed_radius);
+
+  if (diamond_cost < 0)
+  {
+    return -1.0;
+  }
+
+  return std::max<double>(loop_cost, diamond_cost);
+}
+
+double CostmapModel::footprintCostDiamondX(const geometry_msgs::Point& position,
+                                           const std::vector<geometry_msgs::Point>& footprint,
+                                           double inscribed_radius, double circumscribed_radius)
+{
+  const double footprint_diamond = footprintCostDiamond(position, footprint, inscribed_radius, circumscribed_radius);
+
+  if (footprint_diamond < 0)
+  {
+    return -1.0;
+  }
+
+  const double x_cost = xCost(position, footprint, inscribed_radius, circumscribed_radius);
+
+  if (x_cost < 0)
+  {
+    return -1.0;
+  }
+
+  return std::max<double>(x_cost, footprint_diamond);
+}
+
+double CostmapModel::footprintCostEveryPixel(const geometry_msgs::Point& position,
+                                             const std::vector<geometry_msgs::Point>& footprint,
+                                             double inscribed_radius,
+                                             double circumscribed_radius)
+{
+  // we assume the polygon is given in the global_frame... we need to transform it to map coordinates
+  std::vector<costmap_2d::MapLocation> map_polygon;
+  for (unsigned int i = 0; i < footprint.size(); ++i)
+  {
+    costmap_2d::MapLocation loc;
+    if (!costmap_.worldToMap(footprint[i].x, footprint[i].y, loc.x, loc.y))
+    {
+      // footprint lies outside map bounds
+      return costmap_2d::LETHAL_OBSTACLE;
+    }
+    map_polygon.push_back(loc);
+  }
+
+  std::vector<costmap_2d::MapLocation> polygon_cells;
+
+  // get the cells that fill the polygon
+  convexFillCells(map_polygon, polygon_cells);
+
+  unsigned char max_cell = maxCellValue(polygon_cells);
+
+  if (max_cell == costmap_2d::LETHAL_OBSTACLE)
+  {
+    return -1.0;
+  }
+  return max_cell;
+}
+
+double CostmapModel::loopCost(const geometry_msgs::Point& position,
+                              const std::vector<geometry_msgs::Point>& footprint,
+                              double inscribed_radius, double circumscribed_radius)
+{
+  const size_t n = footprint.size();
+  double cost = costmap_2d::FREE_SPACE;
+
+  // check cost of lines made from adjacent vertices
+  for (size_t i = 0; i < n; i++)
+  {
+    size_t j = (i + 1) % n;
+
+    const double line_cost = realLineCost(footprint[i].x, footprint[j].x, footprint[i].y, footprint[j].y);
+
+    if (line_cost < 0)
     {
       return -1.0;
     }
-    
-    //if number of points in the footprint is less than 3, we'll just assume a point robot
-    if(footprint.size() < 3){
-      return cost;
-    }
 
-    //now we really have to lay down the footprint in the costmap grid
-    unsigned int x0, x1, y0, y1;
-    double line_cost = 0.0;
-    double footprint_cost = 0.0;
-
-    //we need to rasterize each line in the footprint
-    for(unsigned int i = 0; i < footprint.size() - 1; ++i){
-      //get the cell coord of the first point
-      if(!costmap_.worldToMap(footprint[i].x, footprint[i].y, x0, y0))
-        return -1.0;
-
-      //get the cell coord of the second point
-      if(!costmap_.worldToMap(footprint[i + 1].x, footprint[i + 1].y, x1, y1))
-        return -1.0;
-
-      line_cost = lineCost(x0, x1, y0, y1);
-      footprint_cost = std::max(line_cost, footprint_cost);
-
-      //if there is an obstacle that hits the line... we know that we can return false right away 
-      if(line_cost < 0)
-        return -1.0;
-    }
-
-    //we also need to connect the first point in the footprint to the last point
-    //get the cell coord of the last point
-    if(!costmap_.worldToMap(footprint.back().x, footprint.back().y, x0, y0))
-      return -1.0;
-
-    //get the cell coord of the first point
-    if(!costmap_.worldToMap(footprint.front().x, footprint.front().y, x1, y1))
-      return -1.0;
-
-    line_cost = lineCost(x0, x1, y0, y1);
-    footprint_cost = std::max(line_cost, footprint_cost);
-
-    if(line_cost < 0)
-      return -1.0;
-
-    //if all line costs are legal... then we can return that the footprint is legal
-    return footprint_cost;
-
+    cost = std::max(line_cost, cost);
   }
 
-  //calculate the cost of a ray-traced line
-  double CostmapModel::lineCost(int x0, int x1, 
-      int y0, int y1){
-    
-    double line_cost = 0.0;
-    double point_cost = -1.0;
+  return cost;
+}
 
-    for( LineIterator line( x0, y0, x1, y1 ); line.isValid(); line.advance() )
-    {
-      point_cost = pointCost( line.getX(), line.getY() ); //Score the current point
-
-      if(point_cost < 0)
-        return -1;
-
-      if(line_cost < point_cost)
-        line_cost = point_cost;
-    }
-
-    return line_cost;
+double CostmapModel::diamondCost(const geometry_msgs::Point& position,
+                                 const std::vector<geometry_msgs::Point>& footprint,
+                                 double inscribed_radius, double circumscribed_radius)
+{
+  const size_t n = footprint.size();
+  if (n == 0)
+  {
+    return realPointCost(position.x, position.y);
   }
 
-  double CostmapModel::pointCost(int x, int y){
-    unsigned char cost = costmap_.getCost(x, y);
-    //if the cell is in an obstacle the path is invalid
-    if(cost == LETHAL_OBSTACLE)
+  if (n == 1)
+  {
+    return realPointCost(footprint[0].x, footprint[0].y);
+  }
+
+  double cost = costmap_2d::FREE_SPACE;
+  // join the midpoints of adjacent edges and check their lines
+  for (size_t i = 0; i < footprint.size(); i ++)
+  {
+    size_t j = (i+1) % footprint.size();
+    size_t k = (i+2) % footprint.size();
+
+    double x0 = 0.5 * (footprint[i].x + footprint[j].x);
+    double x1 = 0.5 * (footprint[j].x + footprint[k].x);
+    double y0 = 0.5 * (footprint[i].y + footprint[j].y);
+    double y1 = 0.5 * (footprint[j].y + footprint[k].y);
+
+    const double line_cost = realLineCost(x0, x1, y0, y1);
+
+    if (line_cost < 0)
     {
       return -1;
     }
 
-    return cost;
+    cost = std::max<double>(cost, line_cost);
   }
 
-};
+  return cost;
+}
+
+double CostmapModel::xCost(const geometry_msgs::Point& position,
+                           const std::vector<geometry_msgs::Point>& footprint,
+                           double inscribed_radius, double circumscribed_radius)
+{
+  const size_t n = footprint.size();
+  if (n == 0)
+  {
+    return realPointCost(position.x, position.y);
+  }
+
+  if (n == 1)
+  {
+    return realPointCost(footprint[0].x, footprint[0].y);
+  }
+
+  if (n == 2)
+  {
+    return realLineCost(footprint[0].x, footprint[1].x, footprint[0].y, footprint[1].y);
+  }
+
+  double cost = costmap_2d::FREE_SPACE;
+  // Join the verts of next nearest vertices on the loop.
+  // This will turn a rectangle into an X
+  //                a pentagon into a 5 pointed star
+  //                a hexagon into 2 overlapping triangles, etc
+  for (size_t i = 0; i < n - 2; i ++)
+  {
+    size_t j = (i + 2) % n;
+
+    const double line_cost = realLineCost(footprint[i].x, footprint[j].x, footprint[i].y, footprint[j].y);
+
+    if (line_cost < 0)
+    {
+      return -1;
+    }
+
+    cost = std::max<double>(cost, line_cost);
+  }
+
+  return cost;
+}
+
+// calculate the cost of a ray-traced line
+double CostmapModel::lineCost(int x0, int x1, int y0, int y1)
+{
+  double line_cost = costmap_2d::FREE_SPACE;
+
+  for (LineIterator line(x0, y0, x1, y1); line.isValid(); line.advance())
+  {
+    const double point_cost = pointCost(line.getX(), line.getY());
+
+    if (point_cost < 0)
+    {
+      return -1;
+    }
+
+    line_cost = std::max<double>(line_cost, point_cost);
+  }
+
+  return line_cost;
+}
+
+double CostmapModel::pointCost(int x, int y)
+{
+  unsigned char cost = costmap_.getCost(x, y);
+
+  if (cost == costmap_2d::LETHAL_OBSTACLE)
+  {
+    return -1.0;
+  }
+
+  return cost;
+}
+
+double CostmapModel::realLineCost(double x0, double x1, double y0, double y1)
+{
+  unsigned int cx0, cy0;
+  unsigned int cx1, cy1;
+
+  if (!costmap_.worldToMap(x0, y0, cx0, cy0))
+  {
+    return -1;
+  }
+
+  if (!costmap_.worldToMap(x1, y1, cx1, cy1))
+  {
+    return -1;
+  }
+
+  return lineCost(cx0, cx1, cy0, cy1);
+}
+
+double CostmapModel::realPointCost(double x, double y)
+{
+  // used to put things into grid coordinates
+  unsigned int cell_x, cell_y;
+
+  // get the cell coord of the center point of the robot
+  if (!costmap_.worldToMap(x, y, cell_x, cell_y))
+  {
+    return -1;
+  }
+
+  unsigned char cost = costmap_.getCost(cell_x, cell_y);
+
+  if (cost == costmap_2d::LETHAL_OBSTACLE)
+  {
+    return -1;
+  }
+  return cost;
+}
+
+double CostmapModel::centerCost(const geometry_msgs::Point& position,
+                                const std::vector<geometry_msgs::Point>& footprint,
+                                double inscribed_radius, double circumscribed_radius)
+{
+  // used to put things into grid coordinates
+  unsigned int cell_x, cell_y;
+
+  // get the cell coord of the center point of the robot
+  if (!costmap_.worldToMap(position.x, position.y, cell_x, cell_y))
+  {
+    return -1;
+  }
+
+  unsigned char cost = costmap_.getCost(cell_x, cell_y);
+
+  if ((cost == costmap_2d::LETHAL_OBSTACLE) |
+      (cost == costmap_2d::INSCRIBED_INFLATED_OBSTACLE))
+  {
+    return -1;
+  }
+
+  return cost;
+}
+
+}  // namespace base_local_planner


### PR DESCRIPTION
including:

- footprint perimeter
- center point check
- an X in the footprint
- a diamond in the footprint
- check every pixel
- combinations of any of the above

The default action is to do a footprint perimeter check, the center point, the diamond plus the X check which reproduces the current checks done in cpr_pathtracker (with the explicit diamond code removed). 

A follow-up PR for pathtracker will be provided that removes the explicit diamond code and use the dense footprint checks for the 0th and 1st footprints.

@skaynama  @p6chen 