### PR TITLE
Allow goal tolerances aware objects to propagate updates to other objects.

### DIFF
--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -50,6 +50,7 @@
 #include <nav_core/recovery_behavior.h>
 #include <nav_core/nav_goal_manager.h>
 #include <nav_core/nav_core_state.h>
+#include <nav_core/goal_tolerances_aware.h>
 
 #include <geometry_msgs/PoseStamped.h>
 #include <costmap_2d/costmap_2d_ros.h>
@@ -83,7 +84,8 @@ namespace move_base {
    * @class MoveBase
    * @brief A class that uses the actionlib::ActionServer interface that moves the robot base to a goal location.
    */
-  class MoveBase {
+  class MoveBase : public nav_core::GoalTolerancesAware
+  {
     public:
       /**
        * @brief  Constructor for the actions
@@ -304,11 +306,6 @@ namespace move_base {
        * @brief Smart pointer to container object to share costmaps and planners
        */
       nav_core::State::Ptr nav_core_state_;
-
-      /**
-       * @brief Smart pointer to object defining goal tolerances
-       */
-      nav_core::GoalTolerances::Ptr goal_tolerances_;
   };
 };
 #endif

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -169,7 +169,7 @@ namespace move_base {
       tc_ = blp_loader_.createInstance(local_planner);
       ROS_INFO("Created local_planner %s", local_planner.c_str());
       tc_->setGoalManager(goal_manager_);
-      tc_->setGoalTolerances(goal_tolerances_);
+      propagateGoalTolerancesTo(tc_);
       tc_->initialize(blp_loader_.getName(local_planner), &tf_, controller_costmap_ros_);
 
     } catch (const pluginlib::PluginlibException& ex)
@@ -336,7 +336,7 @@ namespace move_base {
         controller_plan_->clear();
         resetState();
         tc_->setGoalManager(goal_manager_);
-        tc_->setGoalTolerances(goal_tolerances_);
+        propagateGoalTolerancesTo(tc_);
         tc_->initialize(blp_loader_.getName(config.base_local_planner), &tf_, controller_costmap_ros_);
       } catch (const pluginlib::PluginlibException& ex)
       {
@@ -1386,7 +1386,7 @@ namespace move_base {
       ros::Time t = ros::Time::now();
       global_planner_cache_.insert(std::make_pair(plugin_name, bgp_loader_.createInstance(plugin_name) ) );
       global_planner_cache_[plugin_name]->setGoalManager(goal_manager_);
-      global_planner_cache_[plugin_name]->setGoalTolerances(goal_tolerances_);
+      propagateGoalTolerancesTo(global_planner_cache_[plugin_name]);
       global_planner_cache_[plugin_name]->setNavCoreState(nav_core_state_);
       global_planner_cache_[plugin_name]->initialize(bgp_loader_.getName(plugin_name), planner_costmap_ros_);
       ROS_DEBUG("Created new global planner plugin %s in %f seconds.", plugin_name.c_str(), (ros::Time::now() - t).toSec() );


### PR DESCRIPTION
Made move_base a goal_tolerances aware object and connected it's goal_tolerances with planners and trackers.

@skaynama  @p6chen 