### PR TITLE
Publish zero cmd_vel earlier in the resetState method.

### DIFF
--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -1381,6 +1381,8 @@ namespace move_base {
   }
 
   void MoveBase::resetState(){
+    publishZeroVelocity();  // stop immediately
+
     goal_manager_->setActiveGoal(false);  // setting no active goal
 
     // Disable the planner thread
@@ -1393,7 +1395,6 @@ namespace move_base {
     resetRecoveryIndices();
     state_ = PLANNING;
     recovery_trigger_ = PLANNING_R;
-    publishZeroVelocity();
 
     //if we shutdown our costmaps when we're deactivated... we'll do that now
     if(shutdown_costmaps_){


### PR DESCRIPTION
Ensures a stop happens before recovery cleanup

@skaynama @p6chen 