### PR TITLE
CORE-4119: Stop the robot while we're reverting the recovery changes.…

### DIFF
--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -1443,6 +1443,11 @@ namespace move_base {
       active_recovery_index_ >= 0 &&
       active_recovery_index_ < static_cast<int>(recovery_behaviors_.size()))
     {
+      // First ensure that we're setting velocities to zero so that we're in a safe state
+      // in case reverting a behaviour is time consuming
+      publishZeroVelocity();
+
+      // Now revert the changed caused by the active behaviour
       recovery_behaviors_[active_recovery_index_]->revertChanges();
     }
   }


### PR DESCRIPTION
… Avoids move_base ceasing to publish.

This is necessary because right after calling ```computeVelocityCommands``` we call ```revertRecoveryChanges```. If there's an active recovery then this could potentially take a while to return with no valid command vel having been published in the current control cycle.

@p6chen @jasonimercer 