### PR TITLE
CORE-4224: Added a cycle counter for recovery so that goal abort can be forced ...

### DIFF
--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -241,7 +241,7 @@ namespace move_base {
        * @brief Function that resets the recovery cycle counter and stores the
        * current pose of the robot based on the global costmap.
        */
-      void resetRecoveryCounters();
+      void resetRecoveryCycleState();
 
       /**
        * @brief Convenience function to return the current pose of the robot
@@ -258,7 +258,7 @@ namespace move_base {
        * in short range and if so to force goal abort up the stack.
        * @return True if goal should be aborted, false otherwise.
        */
-      bool forceGoalAbortInRecovery();
+      bool decideOnForcedGoalAbort();
 
       tf::TransformListener& tf_;
 

--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -237,6 +237,28 @@ namespace move_base {
        */
       void asPreemptCallback();
 
+      /**
+       * @brief Function that resets the recovery cycle counter and stores the
+       * current pose of the robot based on the global costmap.
+       */
+      void resetRecoveryCounters();
+
+      /**
+       * @brief Convenience function to return the current pose of the robot
+       * based on a given costmap.
+       * @param costmap Pointer to costmap object.
+       * @param[out] robot_pose The pose of the robot on the costmap.
+       * @return True if successful, false otherwise.
+       */
+      bool getCurrentRobotPose(costmap_2d::Costmap2DROS* costmap,
+        geometry_msgs::PoseStamped& robot_pose);
+
+      /**
+       * @brief Function to decide if too many cycles of recovery has been executed
+       * in short range and if so to force goal abort up the stack.
+       * @return True if goal should be aborted, false otherwise.
+       */
+      bool forceGoalAbortInRecovery();
 
       tf::TransformListener& tf_;
 
@@ -319,6 +341,28 @@ namespace move_base {
        *        will cause the goal to be aborted. Default 0.5 (seconds)
        */
       double minimum_goal_spacing_seconds_;
+
+      /*
+       * @brief Counter for the number of times move_base has gone into recovery.
+       */
+      int recovery_cycle_counter_;
+
+      /**
+       * @brief Counter cap for the number of times move_base has gone into recovery
+       * but the robot hasn't moved in any meaningful way.
+       */
+      int recovery_cycle_counter_cap_;
+
+      /**
+       * @brief Euclidean distance cap on the amount of robot travel before resetting
+       * the recovery cycle counters.
+       */
+      double recovery_cycle_move_cap_;
+
+      /**
+       * @brief Record of the last pose at which the recovery cycle counter is reset.
+       */
+      geometry_msgs::PoseStamped last_pose_at_recovery_reset_;
   };
 };
 #endif

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -916,7 +916,7 @@ namespace move_base {
           lock.unlock();
 
           //publish the goal point to the visualizer
-          ROS_ERROR("move_base has received a goal of x: %.2f, y: %.2f", goal.pose.position.x, goal.pose.position.y);
+          ROS_DEBUG_NAMED("move_base","move_base has received a goal of x: %.2f, y: %.2f", goal.pose.position.x, goal.pose.position.y);
           current_goal_pub_.publish(goal);
 
           //make sure to reset our timeouts
@@ -931,7 +931,7 @@ namespace move_base {
           resetState();
 
           //notify the ActionServer that we've successfully preempted
-          ROS_DEBUG_NAMED("Move base preempting the current goal");
+          ROS_DEBUG_NAMED("move_base","Move base preempting the current goal");
           as_->setPreempted();
 
           //we'll actually return from execute after preempting

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -55,7 +55,10 @@ namespace move_base {
     recovery_loader_("nav_core", "nav_core::RecoveryBehavior"),
     planner_plan_(NULL), latest_plan_(NULL), controller_plan_(NULL),
     runPlanner_(false), setup_(false), p_freq_change_(false), c_freq_change_(false),
-    new_global_plan_(false), recovery_cleanup_requested_(false), nav_core_state_(new nav_core::State)
+    new_global_plan_(false), recovery_cleanup_requested_(false), nav_core_state_(new nav_core::State),
+    recovery_cycle_counter_(0),
+    recovery_cycle_counter_cap_(100),
+    recovery_cycle_move_cap_(2.0)
   {
     goal_manager_.reset(new nav_core::NavGoalMananger);
 
@@ -83,6 +86,9 @@ namespace move_base {
 
     private_nh.param("oscillation_timeout", oscillation_timeout_, 0.0);
     private_nh.param("oscillation_distance", oscillation_distance_, 0.5);
+
+    private_nh.param("recovery_cycle_counter_cap", recovery_cycle_counter_cap_, 10);
+    private_nh.param("recovery_cycle_move_cap", recovery_cycle_move_cap_, 2.0);
 
     // Load goal tolerances (these will eventually be dynamic and come from the action server)
     // The goal tolerances contructor loads from goal_tolerance_xy and goal_tolerance_yaw
@@ -211,10 +217,6 @@ namespace move_base {
     //initially, we'll need to make a plan
     state_ = PLANNING;
 
-    //we'll start executing recovery behaviors at the beginning of our list
-    recovery_index_ = 0;
-    active_recovery_index_ = -1;
-
     //we're all set up now so we can start the action server
     as_->start();
 
@@ -229,6 +231,10 @@ namespace move_base {
     nav_core_state_->local_costmap_ = controller_costmap_ros_;
     nav_core_state_->global_planner_ = planner_;
     nav_core_state_->local_planner_ = tc_;
+
+    // Initialize the recovery counters and indices
+    resetRecoveryIndices();
+    resetRecoveryCounters();
   }
 
   void MoveBase::reconfigureCB(move_base::MoveBaseConfig &config, uint32_t level){
@@ -301,8 +307,6 @@ namespace move_base {
         runPlanner_ = false;
         recovery_cleanup_requested_ = true;
         state_ = PLANNING;
-        recovery_index_ = 0;
-        active_recovery_index_ = -1;
         recovery_trigger_ = PLANNING_R;
         publishZeroVelocity();
 
@@ -702,6 +706,7 @@ namespace move_base {
         recovery_cleanup_requested_ = false;
         revertRecoveryChanges();
         resetRecoveryIndices();
+        resetRecoveryCounters();
       }
 
       ros::Time start_time = ros::Time::now();
@@ -897,6 +902,7 @@ namespace move_base {
           //we'll make sure that we reset our state for the next execution cycle
           revertRecoveryChanges();
           resetRecoveryIndices();
+          resetRecoveryCounters();
           state_ = PLANNING;
 
           //we have a new goal so make sure the planner is awake
@@ -938,6 +944,7 @@ namespace move_base {
         //we want to go back to the planning state for the next execution cycle
         revertRecoveryChanges();
         resetRecoveryIndices();
+        resetRecoveryCounters();
         state_ = PLANNING;
 
         //we have a new goal so make sure the planner is awake
@@ -1025,6 +1032,7 @@ namespace move_base {
       {
         revertRecoveryChanges();
         resetRecoveryIndices();
+        resetRecoveryCounters();
       }
     }
 
@@ -1174,14 +1182,24 @@ namespace move_base {
 
       //we'll try to clear out space with any user-provided recovery behaviors
       case CLEARING:
+      {
         ROS_DEBUG_NAMED("move_base","In clearing/recovery state");
-        if (planner_)
-        {
-          // This invokes the planner's prepareForPostRecovery method to prepare it for post-recovery actions.
-          planner_->prepareForPostRecovery();
-        }
+
+        // Decide if this cycle of recovery should proceed as usual or if we should
+        // force goal abort
+        bool force_abort = forceGoalAbortInRecovery();
+
         //we'll invoke whatever recovery behavior we're currently on if they're enabled
-        if(recovery_behavior_enabled_ && recovery_index_ < recovery_behaviors_.size()){
+        if (recovery_behavior_enabled_
+          && recovery_index_ < recovery_behaviors_.size()
+          && !force_abort)
+        {
+          if (planner_)
+          {
+            // This invokes the planner's prepareForPostRecovery method to prepare it for post-recovery actions.
+            planner_->prepareForPostRecovery();
+          }
+
           ROS_DEBUG_NAMED("move_base_recovery","Executing behavior %u of %zu", recovery_index_, recovery_behaviors_.size());
           active_recovery_index_ = recovery_index_;
           recovery_behaviors_[recovery_index_]->runBehavior();
@@ -1232,6 +1250,7 @@ namespace move_base {
           return true;
         }
         break;
+      }
       default:
         ROS_ERROR("This case should never be reached, something is wrong, aborting");
         resetState();
@@ -1393,6 +1412,7 @@ namespace move_base {
     // Reset statemachine
     revertRecoveryChanges();
     resetRecoveryIndices();
+    resetRecoveryCounters();
     state_ = PLANNING;
     recovery_trigger_ = PLANNING_R;
 
@@ -1481,5 +1501,77 @@ namespace move_base {
     // set a new active goal. For now we will allow behaviours to stop
     // due to no active goal
     goal_manager_->setActiveGoal(false);
+  }
+
+  bool MoveBase::getCurrentRobotPose(costmap_2d::Costmap2DROS* costmap,
+    geometry_msgs::PoseStamped& robot_pose)
+  {
+    if (costmap == NULL)
+    {
+      return false;
+    }
+
+    tf::Stamped<tf::Pose> pose;
+    if (!costmap->getRobotPose(pose) )
+    {
+      return false;
+    }
+
+    // Get the current pose of the robot
+    tf::poseStampedTFToMsg(pose, robot_pose);
+
+    return true;
+  }
+
+  void MoveBase::resetRecoveryCounters()
+  {
+    // Reset the counter
+    recovery_cycle_counter_ = 0;
+
+    // Store the pose
+    geometry_msgs::PoseStamped curr_pose;
+    if (getCurrentRobotPose(planner_costmap_ros_, curr_pose) )
+    {
+      last_pose_at_recovery_reset_ = curr_pose;
+    }
+  }
+
+  bool MoveBase::forceGoalAbortInRecovery()
+  {
+    bool abort = false;
+    bool robot_has_moved_sufficiently = true;
+
+    // Decide if robot has moved sufficiently
+    geometry_msgs::PoseStamped curr_pose;
+    if (getCurrentRobotPose(planner_costmap_ros_, curr_pose) )
+    {
+      robot_has_moved_sufficiently
+        = (distance(curr_pose, last_pose_at_recovery_reset_)
+        > recovery_cycle_move_cap_);
+    }
+
+    if (robot_has_moved_sufficiently)
+    {
+      ROS_ERROR("MoveBase: Robot has moved sufficiently (%.2f with cap %.2f)."
+        " Resetting recovery cycle counters.",
+        distance(curr_pose, last_pose_at_recovery_reset_),
+        recovery_cycle_move_cap_);
+      resetRecoveryCounters();
+    }
+    else if (recovery_cycle_counter_ > recovery_cycle_counter_cap_)
+    {
+      ROS_ERROR("MoveBase: Recovery cycle counter cap reached and "
+        "robot has not moved enough. Forcing goal abort.");
+      resetRecoveryCounters();
+      abort = true;
+    }
+    else
+    {
+      recovery_cycle_counter_++;
+      ROS_ERROR("MoveBase: Executing recovery cycle number %d/%d.",
+        recovery_cycle_counter_, recovery_cycle_counter_cap_);
+    }
+
+    return abort;
   }
 };


### PR DESCRIPTION
... even if the costmap disabling recovery results in recovery index reset.

@p6chen @jasonimercer 

Testing this was tricky. There are situation where the old code would result in goal abort as well (e.g. if the robot is in an open area and the goal is on top of a non-static object). Where this change comes in handy is when the robot is close to an object which causes the moving recoveries to rock the robot back and forth in which case the old code would never report goal abort while this code forces it to.