### PR TITLE
CORE-4296: Brought in bug fix 478 in the inflation layer from upstream

### DIFF
--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -179,8 +179,8 @@ private:
     return layered_costmap_->getCostmap()->cellDistance(world_dist);
   }
 
-  inline void enqueue(unsigned char* grid, unsigned int index, unsigned int mx, unsigned int my, unsigned int src_x,
-                      unsigned int src_y);
+  inline void enqueue(unsigned int index, unsigned int mx, unsigned int my,
+                      unsigned int src_x, unsigned int src_y);
 
   double inflation_radius_, inscribed_radius_, weight_;
   unsigned int cell_inflation_radius_;

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -213,7 +213,7 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
       unsigned char cost = master_array[index];
       if (cost == LETHAL_OBSTACLE)
       {
-        enqueue(master_array, index, i, j, i, j);
+        enqueue(index, i, j, i, j);
       }
     }
   }
@@ -232,31 +232,49 @@ void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, 
     // pop once we have our cell info
     inflation_queue_.pop();
 
+    // set the cost of the cell being inserted
+    if (seen_[index])
+    {
+      continue;
+    }
+
+    seen_[index] = true;
+ 
+    // assign the cost associated with the distance from an obstacle to the cell
+    unsigned char cost = costLookup(mx, my, sx, sy);
+    unsigned char old_cost = master_array[index];
+    if (old_cost == NO_INFORMATION && cost >= INSCRIBED_INFLATED_OBSTACLE)
+    {
+      master_array[index] = cost;
+    }
+    else
+    {
+      master_array[index] = std::max(old_cost, cost);
+    }
+
     // attempt to put the neighbors of the current cell onto the queue
     if (mx > 0)
-      enqueue(master_array, index - 1, mx - 1, my, sx, sy);
+      enqueue(index - 1, mx - 1, my, sx, sy);
     if (my > 0)
-      enqueue(master_array, index - size_x, mx, my - 1, sx, sy);
+      enqueue(index - size_x, mx, my - 1, sx, sy);
     if (mx < size_x - 1)
-      enqueue(master_array, index + 1, mx + 1, my, sx, sy);
+      enqueue(index + 1, mx + 1, my, sx, sy);
     if (my < size_y - 1)
-      enqueue(master_array, index + size_x, mx, my + 1, sx, sy);
+      enqueue(index + size_x, mx, my + 1, sx, sy);
   }
 }
 
 /**
  * @brief  Given an index of a cell in the costmap, place it into a priority queue for obstacle inflation
- * @param  grid The costmap
  * @param  index The index of the cell
  * @param  mx The x coordinate of the cell (can be computed from the index, but saves time to store it)
  * @param  my The y coordinate of the cell (can be computed from the index, but saves time to store it)
  * @param  src_x The x index of the obstacle point inflation started at
  * @param  src_y The y index of the obstacle point inflation started at
  */
-inline void InflationLayer::enqueue(unsigned char* grid, unsigned int index, unsigned int mx, unsigned int my,
-                                            unsigned int src_x, unsigned int src_y)
+inline void InflationLayer::enqueue(unsigned int index, unsigned int mx, unsigned int my,
+                                    unsigned int src_x, unsigned int src_y)
 {
-  // set the cost of the cell being inserted
   if (!seen_[index])
   {
     // we compute our distance table one cell further than the inflation radius dictates so we can make the check below
@@ -266,16 +284,7 @@ inline void InflationLayer::enqueue(unsigned char* grid, unsigned int index, uns
     if (distance > cell_inflation_radius_)
       return;
 
-    // assign the cost associated with the distance from an obstacle to the cell
-    unsigned char cost = costLookup(mx, my, src_x, src_y);
-    unsigned char old_cost = grid[index];
-
-    if (old_cost == NO_INFORMATION && cost >= INSCRIBED_INFLATED_OBSTACLE)
-      grid[index] = cost;
-    else
-      grid[index] = std::max(old_cost, cost);
     // push the cell data onto the queue and mark
-    seen_[index] = true;
     CellData data(distance, index, mx, my, src_x, src_y);
     inflation_queue_.push(data);
   }


### PR DESCRIPTION
https://github.com/ros-planning/navigation/pull/478

"When marking before adding to the priority queue, it was possible to
underestimate the cost of a cell."

@p6chen @jasonimercer 