### PR TITLE
CORE-4311 Refactored abort code and introduced abort throttling.

### DIFF
--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -271,7 +271,7 @@ namespace move_base {
       /**
        * @brief Abort the active goal
        */
-      void abortGoal(std::string abort_message);
+      void abortGoal(const std::string& abort_message);
 
       tf::TransformListener& tf_;
 

--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -268,6 +268,11 @@ namespace move_base {
        */
       bool decideOnForcedGoalAbort();
 
+      /**
+       * @brief Abort the active goal
+       */
+      void abortGoal(std::string abort_message);
+
       tf::TransformListener& tf_;
 
       MoveBaseActionServer* as_;
@@ -377,6 +382,12 @@ namespace move_base {
        * @brief Record of the last pose at which the recovery cycle counter is reset.
        */
       geometry_msgs::PoseStamped last_pose_at_recovery_reset_;
+
+      /**
+       * @brief Last time a goal was aborted. Used as a short-term mitigation strategy
+       *        to throttle fast abort cycles. CORE-4329 will introduce better method.
+       */
+      ros::Time last_abort_goal_;
   };
 };
 #endif

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -1595,7 +1595,7 @@ namespace move_base {
     return abort;
   }
 
-  void MoveBase::abortGoal(std::string abort_message)
+  void MoveBase::abortGoal(const std::string& abort_message)
   {
     // Until CORE-4329, aborts will be throttled to 1 second
     ros::Time next_valid_abort_time = last_abort_goal_ + ros::Duration(1.0);

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -832,8 +832,7 @@ namespace move_base {
     {
       ROS_ERROR_THROTTLE(1, "move_base: Aborting on goal because it was sent too soon after the last goal %gs < %gs",
                              consecutive_goal_time, minimum_goal_spacing_seconds_);
-      as_->setAborted(move_base_msgs::AugmentedMoveBaseResult(), "Aborting on goal because it was sent too soon after the last goal");
-      goal_manager_->setActiveGoal(false);  // setting no active goal
+      abortGoal("Aborting on goal because it was sent too soon after the last goal");
       return;
     }
     last_execute_callback_ = ros_time_now;
@@ -846,14 +845,12 @@ namespace move_base {
     // CORE-3682
     if (move_base_goal.get() == NULL)
     {
-      as_->setAborted(move_base_msgs::AugmentedMoveBaseResult(), "Aborting on goal because it was a NULL pointer");
-      goal_manager_->setActiveGoal(false);  // setting no active goal
+      abortGoal("Aborting on goal because it was a NULL pointer");
       return;
     }
 
     if(!isQuaternionValid(move_base_goal->target_pose.pose.orientation)){
-      as_->setAborted(move_base_msgs::AugmentedMoveBaseResult(), "Aborting on goal because it was sent with an invalid quaternion");
-      goal_manager_->setActiveGoal(false);  // setting no active goal
+      abortGoal("Aborting on goal because it was sent with an invalid quaternion");
       return;
     }
 
@@ -914,15 +911,13 @@ namespace move_base {
 
           if (new_goal_ptr.get() == NULL)
           {
-            as_->setAborted(move_base_msgs::AugmentedMoveBaseResult(), "Aborting on goal because it was NULL");
-            goal_manager_->setActiveGoal(false);  // setting no active goal
+            abortGoal("Aborting on goal because it was NULL");
             return;
           }
 
           move_base_msgs::AugmentedMoveBaseGoal new_goal = *new_goal_ptr;
           if(!isQuaternionValid(new_goal.target_pose.pose.orientation)){
-            as_->setAborted(move_base_msgs::AugmentedMoveBaseResult(), "Aborting on goal because it was sent with an invalid quaternion");
-            goal_manager_->setActiveGoal(false);  // setting no active goal
+            abortGoal("Aborting on goal because it was sent with an invalid quaternion");
             return;
           }
 
@@ -994,7 +989,7 @@ namespace move_base {
     lock.unlock();
 
     //if the node is killed then we'll abort and return
-    as_->setAborted(move_base_msgs::AugmentedMoveBaseResult(), "Aborting on the goal because the node has been killed");
+    abortGoal("Aborting on the goal because the node has been killed");
     return;
   }
 
@@ -1071,7 +1066,7 @@ namespace move_base {
         runPlanner_ = false;
         lock.unlock();
 
-        as_->setAborted(move_base_msgs::AugmentedMoveBaseResult(), "Failed to pass global plan to the controller.");
+        abortGoal("Failed to pass global plan to the controller.");
         return true;
       }
     }
@@ -1248,23 +1243,23 @@ namespace move_base {
           if (recovery_trigger_ == CONTROLLING_R)
           {
             ROS_ERROR_COND(log_condition, "Aborting because a valid control could not be found. Even after executing all recovery behaviors");
-            as_->setAborted(move_base_msgs::AugmentedMoveBaseResult(), "Failed to find a valid control. Even after executing recovery behaviors.");
+            abortGoal("Failed to find a valid control. Even after executing recovery behaviors.");
           }
           else if (recovery_trigger_ == PLANNING_R)
           {
             ROS_ERROR_COND(log_condition, "Aborting because a valid plan could not be found. Even after executing all recovery behaviors");
-            as_->setAborted(move_base_msgs::AugmentedMoveBaseResult(), "Failed to find a valid plan. Even after executing recovery behaviors.");
+            abortGoal("Failed to find a valid plan. Even after executing recovery behaviors.");
           }
           else if (recovery_trigger_ == OSCILLATION_R)
           {
             ROS_ERROR_COND(log_condition, "Aborting because the robot appears to be oscillating over and over. Even after executing all recovery behaviors");
-            as_->setAborted(move_base_msgs::AugmentedMoveBaseResult(), "Robot is oscillating. Even after executing recovery behaviors.");
+            abortGoal("Robot is oscillating. Even after executing recovery behaviors.");
           }
         }
         else if (failure_mode_ == PLANNING_F)
         {
           ROS_ERROR_COND(log_condition, "Fatal planning error.");
-          as_->setAborted(move_base_msgs::AugmentedMoveBaseResult(), "Fatal planning error.");
+          abortGoal("Fatal planning error.");
         }
 
         // Record the failed goal so in the next cycle we don't log a new message
@@ -1278,7 +1273,7 @@ namespace move_base {
         boost::unique_lock<boost::mutex> lock(planner_mutex_);
         runPlanner_ = false;
         lock.unlock();
-        as_->setAborted(move_base_msgs::AugmentedMoveBaseResult(), "Reached a case that should not be hit in move_base. This is a bug, please report it.");
+        abortGoal("Reached a case that should not be hit in move_base. This is a bug, please report it.");
         return true;
     }
 
@@ -1599,4 +1594,21 @@ namespace move_base {
 
     return abort;
   }
+
+  void MoveBase::abortGoal(std::string abort_message)
+  {
+    // Until CORE-4329, aborts will be throttled to 1 second
+    ros::Time next_valid_abort_time = last_abort_goal_ + ros::Duration(1.0);
+
+    // sleep for difference between next abort time and now (negative duration will return immediately)
+    (next_valid_abort_time - ros::Time::now()).sleep();
+
+    // update last abort time for throttling
+    last_abort_goal_ = ros::Time::now();
+
+    // do the abort
+    as_->setAborted(move_base_msgs::AugmentedMoveBaseResult(), abort_message);
+    goal_manager_->setActiveGoal(false);  // setting no active goal
+  }
+
 };


### PR DESCRIPTION
Before this is was possible to get the action server into a bad state with fast abort cycles now possible with the abort-when-planning-into-wall code. Strategy management would lock up.

Better solution will be CORE-4329.

@p6chen @abencz 