### PR TITLE
On move_base shutdown, stop planning thread before deleting the costmaps and layers.

### DIFF
--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -559,6 +559,9 @@ namespace move_base {
   }
 
   MoveBase::~MoveBase(){
+    planner_thread_->interrupt();
+    planner_thread_->join();
+
     delete dsrv_;
 
     as_feedback_timer_.stop();
@@ -570,9 +573,6 @@ namespace move_base {
 
     if(controller_costmap_ros_ != NULL)
       delete controller_costmap_ros_;
-
-    planner_thread_->interrupt();
-    planner_thread_->join();
 
     delete planner_thread_;
 


### PR DESCRIPTION
CORE-4449

@schopra01 @skaynama @p6chen 