### PR TITLE
Added namespace and mutex to the move_base diagnostic publisher.

### DIFF
--- a/move_base/include/move_base/diagnostic_publisher.h
+++ b/move_base/include/move_base/diagnostic_publisher.h
@@ -18,6 +18,11 @@ express permission of Clearpath Robotics.
 #include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 
+#include <boost/thread/recursive_mutex.hpp>
+#include <boost/thread.hpp>
+
+namespace move_base
+{
 
 /**
  * Class for convenient publishing of diagnostic status messages.
@@ -48,6 +53,10 @@ private:
   std::string name_;
   char level_;
   std::string message_;
+
+  boost::recursive_mutex mutex_;
 };
+
+}  // namespace move_base
 
 #endif  // MOVE_BASE_DIAGNOSTIC_PUBLISHER_H


### PR DESCRIPTION
The diagnostic publisher could be called from multiple threads in move_base simultaneously, corrupting the internal state and crashing move_base. 

Without the namespace, some loaded libraries that share the diagnostic publisher code would crash as we are changing the size of the object. The namespace ensures this version of the publisher is treated uniquely wrt other publishers. (Should collect the publisher code in a common place).

@skaynama @p6chen @schopra01 

FYI: @stephmcarthur 